### PR TITLE
feat: fluxo hierárquico de seleção de atividades no wizard de avaliação

### DIFF
--- a/apps/api/Controllers/AvaliacaoDiagnosticaController.cs
+++ b/apps/api/Controllers/AvaliacaoDiagnosticaController.cs
@@ -49,7 +49,8 @@ public class AvaliacaoDiagnosticaController : ControllerBase
     [HttpGet("buscar/{id}")]
     public async Task<IActionResult> BuscarPorId(int id)
     {
-        var resposta = await _service.GetById(id);
+        var usuario = await _userManager.GetUserAsync(User);
+        var resposta = await _service.GetById(id, usuario);
         if (!resposta.Sucesso)
         {
             return resposta.Mensagens.Any(m => m.Contains("não encontrada"))
@@ -116,7 +117,8 @@ public class AvaliacaoDiagnosticaController : ControllerBase
     {
         try
         {
-            var pdfBytes = await _service.GerarPdfBytesAsync(id);
+            var usuario = await _userManager.GetUserAsync(User);
+            var pdfBytes = await _service.GerarPdfBytesAsync(id, usuario);
             return File(pdfBytes, "application/pdf", $"avaliacao-{id}.pdf");
         }
         catch (InvalidOperationException ex)

--- a/apps/api/Services/AvaliacaoDiagnosticaService.cs
+++ b/apps/api/Services/AvaliacaoDiagnosticaService.cs
@@ -501,13 +501,16 @@ namespace api.Services
             }
         }
 
-        public async Task<ServiceResponse<AvaliacaoDiagnosticaDetailDTO>> GetById(int id)
+        public async Task<ServiceResponse<AvaliacaoDiagnosticaDetailDTO>> GetById(int id, Usuario usuario)
         {
             var resposta = new ServiceResponse<AvaliacaoDiagnosticaDetailDTO>();
             try
             {
-                var avaliacaoExiste = await _contexto.AvaliacoesDiagnosticas.AnyAsync(a => a.Id == id);
-                if (!avaliacaoExiste)
+                var avaliacao = await _contexto.AvaliacoesDiagnosticas
+                    .FirstOrDefaultAsync(a => a.Id == id &&
+                        (a.ProfessorId == usuario.ProfessorId || a.ProfessorId == null));
+
+                if (avaliacao == null)
                 {
                     resposta.SetFalha($"Avaliação diagnóstica com ID {id} não encontrada.");
                     return resposta;
@@ -689,9 +692,9 @@ namespace api.Services
             }
         }
 
-        public async Task<byte[]> GerarPdfBytesAsync(int avaliacaoId)
+        public async Task<byte[]> GerarPdfBytesAsync(int avaliacaoId, Usuario usuario)
         {
-            var resposta = await GetById(avaliacaoId);
+            var resposta = await GetById(avaliacaoId, usuario);
             if (!resposta.Sucesso || resposta.Objeto == null)
             {
                 throw new InvalidOperationException("Avaliação não encontrada ou erro ao carregar dados.");

--- a/apps/web-app/src/pages/avaliacao/steps/WizardStep3Areas.tsx
+++ b/apps/web-app/src/pages/avaliacao/steps/WizardStep3Areas.tsx
@@ -1,18 +1,30 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { buscarBlocosComAtividades } from '@/services/blocosService'
 import { useAvaliacaoWizardStore } from '@/stores/avaliacaoWizardStore'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { ArrowLeft, ArrowRight, CaretDown, CaretUp, CheckSquare, Square } from '@phosphor-icons/react'
+import { ArrowLeft, ArrowRight, CheckSquare, Square } from '@phosphor-icons/react'
 import { cn, sortByField } from '@/lib/utils'
+
+const NIVEIS: { value: 'Facil' | 'Medio' | 'Dificil'; label: string }[] = [
+  { value: 'Facil', label: 'Fácil' },
+  { value: 'Medio', label: 'Médio' },
+  { value: 'Dificil', label: 'Difícil' },
+]
+
+const ETAPAS_ORDEM = ['EI', 'EF1', 'EF2']
 
 export function WizardStep3Areas() {
   const navigate = useNavigate()
   const { data: wizardData, updateData, markStepComplete, isEditing, avaliacaoId } = useAvaliacaoWizardStore()
-  const [expandedBlocos, setExpandedBlocos] = useState<Record<number, boolean>>({})
   const [error, setError] = useState('')
+
+  const [eixoId, setEixoId] = useState<number | null>(null)
+  const [nivel, setNivel] = useState<string | null>(null)
+  const [etapa, setEtapa] = useState<string | null>(null)
 
   const { data: blocos = [], isLoading } = useQuery({
     queryKey: ['blocos-com-atividades'],
@@ -42,29 +54,57 @@ export function WizardStep3Areas() {
   }, [wizardData.blocoIds, wizardData.blocos])
 
   const selectedCount = useMemo(
-    () => Object.values(selectedByBloco).reduce((acc, atividades) => acc + atividades.length, 0),
+    () => Object.values(selectedByBloco).reduce((acc, ids) => acc + ids.length, 0),
     [selectedByBloco]
   )
 
-  function toggleExpand(id: number) {
-    setExpandedBlocos((prev) => ({ ...prev, [id]: !prev[id] }))
+  const blocoAtual = useMemo(() => blocos.find((b) => b.id === eixoId) ?? null, [blocos, eixoId])
+
+  const niveisDisponiveis = useMemo(() => {
+    if (!blocoAtual) return []
+    const set = new Set(blocoAtual.atividades.map((a) => a.nivel).filter(Boolean))
+    return NIVEIS.filter((n) => set.has(n.value))
+  }, [blocoAtual])
+
+  const etapasDisponiveis = useMemo(() => {
+    if (!blocoAtual || !nivel) return []
+    const atividadesFiltradas = blocoAtual.atividades.filter((a) => a.nivel === nivel)
+    const set = new Set<string>()
+    for (const a of atividadesFiltradas) {
+      if (a.etapaMin) set.add(a.etapaMin)
+      if (a.etapaMax) set.add(a.etapaMax)
+    }
+    return ETAPAS_ORDEM.filter((e) => set.has(e))
+  }, [blocoAtual, nivel])
+
+  const atividadesFiltradas = useMemo(() => {
+    if (!blocoAtual || !nivel || !etapa) return []
+    return blocoAtual.atividades.filter(
+      (a) => a.nivel === nivel && (a.etapaMin === etapa || a.etapaMax === etapa)
+    )
+  }, [blocoAtual, nivel, etapa])
+
+  function selectEixo(id: number) {
+    setEixoId(id)
+    setNivel(null)
+    setEtapa(null)
+  }
+
+  function selectNivel(n: string) {
+    setNivel(n)
+    setEtapa(null)
   }
 
   function toggleAtividade(blocoId: number, atividadeId: number) {
     setSelectedByBloco((prev) => {
-      const selectedAtual = prev[blocoId] ?? []
-      const jaSelecionado = selectedAtual.includes(atividadeId)
-      const proximo = jaSelecionado
-        ? selectedAtual.filter((id) => id !== atividadeId)
-        : [...selectedAtual, atividadeId]
-
-      const nextState = { ...prev }
-      if (proximo.length === 0) {
-        delete nextState[blocoId]
-      } else {
-        nextState[blocoId] = proximo
-      }
-      return nextState
+      const atual = prev[blocoId] ?? []
+      const proximo = atual.includes(atividadeId)
+        ? atual.filter((id) => id !== atividadeId)
+        : [...atual, atividadeId]
+      const next = { ...prev }
+      if (proximo.length === 0) delete next[blocoId]
+      else next[blocoId] = proximo
+      return next
     })
     setError('')
   }
@@ -80,10 +120,7 @@ export function WizardStep3Areas() {
       return
     }
 
-    updateData({
-      blocoIds: blocosSelecionados.map((b) => b.blocoId),
-      blocos: blocosSelecionados,
-    })
+    updateData({ blocoIds: blocosSelecionados.map((b) => b.blocoId), blocos: blocosSelecionados })
     markStepComplete('areas')
     navigate(isEditing && avaliacaoId ? `/avaliacoes/editar/${avaliacaoId}/preview` : '/avaliacoes/nova/preview')
   }
@@ -93,91 +130,145 @@ export function WizardStep3Areas() {
       <div className="mb-6">
         <h2 className="text-xl font-bold text-foreground">Selecionar Áreas</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Escolha os blocos de atividades que serão aplicados nesta avaliação.
+          Escolha as atividades por eixo, nível de dificuldade e etapa de ensino.
         </p>
       </div>
 
       <div className="space-y-4">
         {selectedCount > 0 && (
-          <Badge variant="default">{selectedCount} atividade{selectedCount !== 1 ? 's' : ''} selecionada{selectedCount !== 1 ? 's' : ''}</Badge>
+          <Badge variant="default">
+            {selectedCount} atividade{selectedCount !== 1 ? 's' : ''} selecionada{selectedCount !== 1 ? 's' : ''}
+          </Badge>
         )}
 
         {isLoading ? (
           <div className="space-y-2">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="skeleton h-20 rounded-xl" />
-            ))}
+            {[1, 2, 3].map((i) => <div key={i} className="skeleton h-14 rounded-xl" />)}
           </div>
-        ) : blocos.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-8">
-            Nenhum bloco disponível.
-          </p>
         ) : (
-          <div className="space-y-2">
-            {sortByField(blocos, 'titulo').map((bloco) => {
-              const atividadesSelecionadas = selectedByBloco[bloco.id] ?? []
-              const isSelected = atividadesSelecionadas.length > 0
-              const expanded = expandedBlocos[bloco.id] ?? isSelected
+          <>
+            {/* Passo 1 — Eixo */}
+            <FilterSection step="1" label="Selecione o Eixo">
+              <div className="flex flex-wrap gap-2">
+                {sortByField(blocos, 'titulo').map((bloco) => {
+                  const count = selectedByBloco[bloco.id]?.length ?? 0
+                  const isActive = eixoId === bloco.id
+                  return (
+                    <button
+                      key={bloco.id}
+                      type="button"
+                      onClick={() => selectEixo(bloco.id)}
+                      className={cn(
+                        'px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors',
+                        isActive
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : count > 0
+                            ? 'border-primary/60 bg-primary-light text-primary'
+                            : 'border-border bg-card text-foreground hover:border-primary/40'
+                      )}
+                    >
+                      {bloco.titulo}
+                      {count > 0 && <span className="ml-1.5 text-xs opacity-80">({count})</span>}
+                    </button>
+                  )
+                })}
+              </div>
+            </FilterSection>
 
-              return (
-                <div
-                  key={bloco.id}
-                  className={cn(
-                    'w-full p-4 rounded-xl border transition-all duration-150 text-left',
-                    isSelected
-                      ? 'border-primary bg-primary-light'
-                      : 'border-border bg-card hover:border-primary/40'
-                  )}
-                >
-                  <button type="button" onClick={() => toggleExpand(bloco.id)} className="w-full flex items-start gap-3 cursor-pointer">
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-bold text-foreground">{bloco.titulo}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {atividadesSelecionadas.length} de {bloco.atividades.length} atividade{bloco.atividades.length !== 1 ? 's' : ''} selecionada{bloco.atividades.length !== 1 ? 's' : ''}
-                      </p>
-                    </div>
-                    {isSelected ? (
-                      <CheckSquare size={18} className="text-primary shrink-0 mt-0.5" weight="fill" />
-                    ) : (
-                      <Square size={18} className="text-muted-foreground shrink-0 mt-0.5" />
-                    )}
-                    {expanded ? <CaretUp size={18} className="text-muted-foreground shrink-0 mt-0.5" /> : <CaretDown size={18} className="text-muted-foreground shrink-0 mt-0.5" />}
-                  </button>
+            {/* Passo 2 — Nível */}
+            {eixoId !== null && (
+              <FilterSection step="2" label="Selecione o Nível de Dificuldade">
+                {niveisDisponiveis.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">Nenhum nível disponível para este eixo.</p>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {niveisDisponiveis.map((n) => (
+                      <button
+                        key={n.value}
+                        type="button"
+                        onClick={() => selectNivel(n.value)}
+                        className={cn(
+                          'px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors',
+                          nivel === n.value
+                            ? 'border-primary bg-primary text-primary-foreground'
+                            : 'border-border bg-card text-foreground hover:border-primary/40'
+                        )}
+                      >
+                        {n.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </FilterSection>
+            )}
 
-                  {expanded && (
-                    <div className="mt-3 space-y-2 pl-1">
-                      {bloco.atividades.map((atividade) => {
-                        const checked = atividadesSelecionadas.includes(atividade.id)
-                        return (
-                          <button
-                            key={atividade.id}
-                            type="button"
-                            onClick={() => toggleAtividade(bloco.id, atividade.id)}
-                            className={cn(
-                              'w-full flex items-start justify-between rounded-lg border px-3 py-2 cursor-pointer',
-                              checked ? 'border-primary bg-primary/10' : 'border-border bg-background'
+            {/* Passo 3 — Etapa */}
+            {eixoId !== null && nivel !== null && (
+              <FilterSection step="3" label="Selecione a Etapa de Ensino">
+                {etapasDisponiveis.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">Nenhuma etapa disponível para este nível.</p>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {etapasDisponiveis.map((e) => (
+                      <button
+                        key={e}
+                        type="button"
+                        onClick={() => setEtapa(e)}
+                        className={cn(
+                          'px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors',
+                          etapa === e
+                            ? 'border-primary bg-primary text-primary-foreground'
+                            : 'border-border bg-card text-foreground hover:border-primary/40'
+                        )}
+                      >
+                        {e}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </FilterSection>
+            )}
+
+            {/* Passo 4 — Atividades */}
+            {eixoId !== null && nivel !== null && etapa !== null && (
+              <FilterSection step="4" label="Selecione as Atividades">
+                {atividadesFiltradas.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    Nenhuma atividade encontrada com esses filtros.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {atividadesFiltradas.map((atividade) => {
+                      const checked = (selectedByBloco[eixoId] ?? []).includes(atividade.id)
+                      return (
+                        <button
+                          key={atividade.id}
+                          type="button"
+                          onClick={() => toggleAtividade(eixoId, atividade.id)}
+                          className={cn(
+                            'w-full flex items-start justify-between rounded-lg border px-3 py-2 cursor-pointer text-left',
+                            checked ? 'border-primary bg-primary/10' : 'border-border bg-background'
+                          )}
+                        >
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold text-foreground">{atividade.titulo}</p>
+                            {atividade.enunciado && (
+                              <p className="text-xs text-muted-foreground line-clamp-2">{atividade.enunciado}</p>
                             )}
-                          >
-                            <div className="min-w-0">
-                              <p className="text-sm font-semibold text-foreground truncate">{atividade.titulo}</p>
-                              {atividade.enunciado && (
-                                <p className="text-xs text-muted-foreground line-clamp-2">{atividade.enunciado}</p>
-                              )}
-                            </div>
-                            {checked ? (
-                              <CheckSquare size={16} className="text-primary shrink-0 ml-2 mt-0.5" weight="fill" />
-                            ) : (
-                              <Square size={16} className="text-muted-foreground shrink-0 ml-2 mt-0.5" />
-                            )}
-                          </button>
-                        )
-                      })}
-                    </div>
-                  )}
-                </div>
-              )
-            })}
-          </div>
+                          </div>
+                          {checked ? (
+                            <CheckSquare size={16} className="text-primary shrink-0 ml-2 mt-0.5" weight="fill" />
+                          ) : (
+                            <Square size={16} className="text-muted-foreground shrink-0 ml-2 mt-0.5" />
+                          )}
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+              </FilterSection>
+            )}
+          </>
         )}
 
         {error && <p className="text-xs text-danger font-medium">{error}</p>}
@@ -196,6 +287,17 @@ export function WizardStep3Areas() {
           </Button>
         </div>
       </div>
+    </div>
+  )
+}
+
+function FilterSection({ step, label, children }: { step: string; label: string; children: ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+        {step}. {label}
+      </p>
+      {children}
     </div>
   )
 }

--- a/apps/web-app/src/pages/relatorios/RelatoriosPage.tsx
+++ b/apps/web-app/src/pages/relatorios/RelatoriosPage.tsx
@@ -63,10 +63,13 @@ export default function RelatoriosPage() {
   const avaliacaoIdInicial = avaliacaoIdQuery ? Number(avaliacaoIdQuery) : null
   const [avaliacaoId, setAvaliacaoId] = useState<number | null>(null)
 
-  const { data: avaliacoes = [], isLoading: loadingAv } = useQuery({
+  const { data: todasAvaliacoes = [], isLoading: loadingAv } = useQuery({
     queryKey: ['avaliacoes-diagnosticas'],
     queryFn: buscarAvaliacoesDiagnosticas,
   })
+
+  // Exclui avaliações órfãs (sem dono) do relatório — podem conter alunos de outras professoras
+  const avaliacoes = todasAvaliacoes.filter((av) => av.professorId != null)
 
   const { data: avaliacaoDetalhada, isLoading: loadingDetalhe } = useQuery({
     queryKey: ['avaliacao-detalhada', avaliacaoId],


### PR DESCRIPTION
Substitui a listagem flat de blocos/atividades por um fluxo em cascata:
1. Eixo → 2. Nível de dificuldade → 3. Etapa de ensino → 4. Atividades filtradas

Cada passo só aparece após o anterior ser selecionado, e os filtros mostram apenas as opções disponíveis para o contexto atual. A seleção acumulada entre diferentes combinações de filtro é preservada.