### PR TITLE
fix(planejamento): lote de vínculos e teto de pool no Postgres

### DIFF
--- a/apps/api/Controllers/PlanejamentoController.cs
+++ b/apps/api/Controllers/PlanejamentoController.cs
@@ -182,6 +182,78 @@ namespace api.Controllers
             }
         }
 
+        [HttpPost("vincularalunoslote")]
+        public async Task<IActionResult> VincularAlunosEmLote([FromBody] PlanejamentoVincularAlunosLoteDTO dto)
+        {
+            if (ModelState.IsValid)
+            {
+                var usuario = await _usuario.GetUserAsync(User);
+                var resposta = await _planejamentoService.VincularAlunosEmLote(dto, usuario);
+                if (resposta.Sucesso)
+                {
+                    return Ok(resposta);
+                }
+
+                return BadRequest(resposta);
+            }
+
+            return BadRequest(ModelState);
+        }
+
+        [HttpPost("vincularhabilidadeslote")]
+        public async Task<IActionResult> VincularHabilidadesEmLote([FromBody] PlanejamentoVincularHabilidadesLoteDTO dto)
+        {
+            if (ModelState.IsValid)
+            {
+                var usuario = await _usuario.GetUserAsync(User);
+                var resposta = await _planejamentoService.VincularHabilidadesEmLote(dto, usuario);
+                if (resposta.Sucesso)
+                {
+                    return Ok(resposta);
+                }
+
+                return BadRequest(resposta);
+            }
+
+            return BadRequest(ModelState);
+        }
+
+        [HttpPost("vincularestrategiaslote")]
+        public async Task<IActionResult> VincularEstrategiasEmLote([FromBody] PlanejamentoVincularEstrategiasLoteDTO dto)
+        {
+            if (ModelState.IsValid)
+            {
+                var usuario = await _usuario.GetUserAsync(User);
+                var resposta = await _planejamentoService.VincularEstrategiasEmLote(dto, usuario);
+                if (resposta.Sucesso)
+                {
+                    return Ok(resposta);
+                }
+
+                return BadRequest(resposta);
+            }
+
+            return BadRequest(ModelState);
+        }
+
+        [HttpPost("vincularavaliacoeslote")]
+        public async Task<IActionResult> VincularAvaliacoesEmLote([FromBody] PlanejamentoVincularAvaliacoesLoteDTO dto)
+        {
+            if (ModelState.IsValid)
+            {
+                var usuario = await _usuario.GetUserAsync(User);
+                var resposta = await _planejamentoService.VincularAvaliacoesEmLote(dto, usuario);
+                if (resposta.Sucesso)
+                {
+                    return Ok(resposta);
+                }
+
+                return BadRequest(resposta);
+            }
+
+            return BadRequest(ModelState);
+        }
+
         [HttpDelete("{id}")]
         public async Task<IActionResult> Excluir(int id)
         {

--- a/apps/api/DTOs/Planejamento/PlanejamentoVincularAlunosLoteDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoVincularAlunosLoteDTO.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.DTOs.Planejamento
+{
+    public class PlanejamentoVincularAlunosLoteDTO
+    {
+        [Required(ErrorMessage = "O campo idPlanejamento é obrigatório.")]
+        public int IdPlanejamento { get; set; }
+
+        [Required(ErrorMessage = "A lista idAlunos é obrigatória.")]
+        [MinLength(1, ErrorMessage = "Informe pelo menos um aluno.")]
+        public List<int> IdAlunos { get; set; } = [];
+    }
+}

--- a/apps/api/DTOs/Planejamento/PlanejamentoVincularAvaliacoesLoteDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoVincularAvaliacoesLoteDTO.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.DTOs.Planejamento
+{
+    public class PlanejamentoVincularAvaliacoesLoteDTO
+    {
+        [Required(ErrorMessage = "O campo idPlanejamento é obrigatório.")]
+        public int IdPlanejamento { get; set; }
+
+        public List<int> IdAvaliacoes { get; set; } = [];
+    }
+}

--- a/apps/api/DTOs/Planejamento/PlanejamentoVincularEstrategiasLoteDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoVincularEstrategiasLoteDTO.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.DTOs.Planejamento
+{
+    public class PlanejamentoVincularEstrategiasLoteDTO
+    {
+        [Required(ErrorMessage = "O campo idPlanejamento é obrigatório.")]
+        public int IdPlanejamento { get; set; }
+
+        public List<int> IdEstrategias { get; set; } = [];
+    }
+}

--- a/apps/api/DTOs/Planejamento/PlanejamentoVincularHabilidadesLoteDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoVincularHabilidadesLoteDTO.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.DTOs.Planejamento
+{
+    public class PlanejamentoVincularHabilidadesLoteDTO
+    {
+        [Required(ErrorMessage = "O campo idPlanejamento é obrigatório.")]
+        public int IdPlanejamento { get; set; }
+
+        public List<int> IdHabilidades { get; set; } = [];
+    }
+}

--- a/apps/api/Program.cs
+++ b/apps/api/Program.cs
@@ -96,6 +96,13 @@ var connectionString = baseConnectionString
     .Replace("{SERVER_URL}", builder.Configuration["SERVER_URL"])
     .Replace("{PORT_API}", builder.Configuration["PORT_API"]);
 
+// Limita conexões por instância (evita "Max client connections reached" no Postgres).
+// Produção: ajuste Database:MaxPoolSize ou variável de ambiente Database__MaxPoolSize conforme max_connections ÷ instâncias da API.
+var maxPoolSize = builder.Configuration.GetValue("Database:MaxPoolSize", 20);
+if (maxPoolSize < 1)
+    maxPoolSize = 20;
+connectionString = $"{connectionString.TrimEnd(';')};Maximum Pool Size={maxPoolSize}";
+
 // Registra DbContext
 builder.Services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
 

--- a/apps/api/Services/PlanejamentoService.cs
+++ b/apps/api/Services/PlanejamentoService.cs
@@ -447,5 +447,193 @@ namespace api.Services
             resposta.Sucesso = true;
             return resposta;
         }
+
+        public async Task<ServiceResponse<bool>> VincularAlunosEmLote(PlanejamentoVincularAlunosLoteDTO dto, Usuario usuario)
+        {
+            var resposta = new ServiceResponse<bool>();
+            var distinctIds = dto.IdAlunos.Distinct().ToList();
+            if (distinctIds.Count == 0)
+            {
+                resposta.SetFalha("Informe pelo menos um aluno.");
+                return resposta;
+            }
+
+            var planejamento = await _contexto.Planejamentos
+                .FirstOrDefaultAsync(p => p.ID == dto.IdPlanejamento && p.IdProfessor == usuario.ProfessorId);
+            if (planejamento == null)
+            {
+                resposta.SetFalha("Planejamento não encontrado.");
+                return resposta;
+            }
+
+            var alunosEncontrados = await _contexto.Alunos
+                .Where(a => distinctIds.Contains(a.Id) && a.IdProfessor == usuario.ProfessorId)
+                .Select(a => a.Id)
+                .ToListAsync();
+            if (alunosEncontrados.Count != distinctIds.Count)
+            {
+                resposta.SetFalha("Um ou mais alunos não foram encontrados.");
+                return resposta;
+            }
+
+            var jaVinculados = await _contexto.AlunosXPlanejamentos
+                .Where(x => x.PlanejamentoId == dto.IdPlanejamento && distinctIds.Contains(x.AlunoId))
+                .Select(x => x.AlunoId)
+                .ToListAsync();
+            var setJa = jaVinculados.ToHashSet();
+            foreach (var alunoId in distinctIds.Where(id => !setJa.Contains(id)))
+            {
+                _contexto.AlunosXPlanejamentos.Add(new AlunosXPlanejamento
+                {
+                    AlunoId = alunoId,
+                    PlanejamentoId = dto.IdPlanejamento
+                });
+            }
+
+            await _contexto.SaveChangesAsync();
+            resposta.Sucesso = true;
+            return resposta;
+        }
+
+        public async Task<ServiceResponse<bool>> VincularHabilidadesEmLote(PlanejamentoVincularHabilidadesLoteDTO dto, Usuario usuario)
+        {
+            var resposta = new ServiceResponse<bool>();
+            var distinctIds = dto.IdHabilidades.Distinct().ToList();
+            if (distinctIds.Count == 0)
+            {
+                resposta.Sucesso = true;
+                return resposta;
+            }
+
+            var planejamento = await _contexto.Planejamentos
+                .FirstOrDefaultAsync(p => p.ID == dto.IdPlanejamento && p.IdProfessor == usuario.ProfessorId);
+            if (planejamento == null)
+            {
+                resposta.SetFalha("Planejamento não encontrado.");
+                return resposta;
+            }
+
+            var encontradas = await _contexto.Habilidades
+                .Where(h => distinctIds.Contains(h.Id))
+                .Select(h => h.Id)
+                .ToListAsync();
+            if (encontradas.Count != distinctIds.Count)
+            {
+                resposta.SetFalha("Uma ou mais habilidades não foram encontradas.");
+                return resposta;
+            }
+
+            var jaVinculados = await _contexto.HabilidadesXPlanejamentos
+                .Where(x => x.PlanejamentoId == dto.IdPlanejamento && distinctIds.Contains(x.HabilidadeId))
+                .Select(x => x.HabilidadeId)
+                .ToListAsync();
+            var setJa = jaVinculados.ToHashSet();
+            foreach (var hid in distinctIds.Where(id => !setJa.Contains(id)))
+            {
+                _contexto.HabilidadesXPlanejamentos.Add(new HabilidadesXPlanejamento
+                {
+                    HabilidadeId = hid,
+                    PlanejamentoId = dto.IdPlanejamento
+                });
+            }
+
+            await _contexto.SaveChangesAsync();
+            resposta.Sucesso = true;
+            return resposta;
+        }
+
+        public async Task<ServiceResponse<bool>> VincularEstrategiasEmLote(PlanejamentoVincularEstrategiasLoteDTO dto, Usuario usuario)
+        {
+            var resposta = new ServiceResponse<bool>();
+            var distinctIds = dto.IdEstrategias.Distinct().ToList();
+            if (distinctIds.Count == 0)
+            {
+                resposta.Sucesso = true;
+                return resposta;
+            }
+
+            var planejamento = await _contexto.Planejamentos
+                .FirstOrDefaultAsync(p => p.ID == dto.IdPlanejamento && p.IdProfessor == usuario.ProfessorId);
+            if (planejamento == null)
+            {
+                resposta.SetFalha("Planejamento não encontrado.");
+                return resposta;
+            }
+
+            var encontradas = await _contexto.Estrategias
+                .Where(e => distinctIds.Contains(e.Id))
+                .Select(e => e.Id)
+                .ToListAsync();
+            if (encontradas.Count != distinctIds.Count)
+            {
+                resposta.SetFalha("Uma ou mais estratégias não foram encontradas.");
+                return resposta;
+            }
+
+            var jaVinculados = await _contexto.EstrategiasXPlanejamentos
+                .Where(x => x.PlanejamentoId == dto.IdPlanejamento && distinctIds.Contains(x.EstrategiaId))
+                .Select(x => x.EstrategiaId)
+                .ToListAsync();
+            var setJa = jaVinculados.ToHashSet();
+            foreach (var eid in distinctIds.Where(id => !setJa.Contains(id)))
+            {
+                _contexto.EstrategiasXPlanejamentos.Add(new EstrategiasXPlanejamento
+                {
+                    EstrategiaId = eid,
+                    PlanejamentoId = dto.IdPlanejamento
+                });
+            }
+
+            await _contexto.SaveChangesAsync();
+            resposta.Sucesso = true;
+            return resposta;
+        }
+
+        public async Task<ServiceResponse<bool>> VincularAvaliacoesEmLote(PlanejamentoVincularAvaliacoesLoteDTO dto, Usuario usuario)
+        {
+            var resposta = new ServiceResponse<bool>();
+            var distinctIds = dto.IdAvaliacoes.Distinct().ToList();
+            if (distinctIds.Count == 0)
+            {
+                resposta.Sucesso = true;
+                return resposta;
+            }
+
+            var planejamento = await _contexto.Planejamentos
+                .FirstOrDefaultAsync(p => p.ID == dto.IdPlanejamento && p.IdProfessor == usuario.ProfessorId);
+            if (planejamento == null)
+            {
+                resposta.SetFalha("Planejamento não encontrado.");
+                return resposta;
+            }
+
+            var encontradas = await _contexto.Avaliacao
+                .Where(a => distinctIds.Contains(a.Id))
+                .Select(a => a.Id)
+                .ToListAsync();
+            if (encontradas.Count != distinctIds.Count)
+            {
+                resposta.SetFalha("Uma ou mais avaliações não foram encontradas.");
+                return resposta;
+            }
+
+            var jaVinculados = await _contexto.AvaliacaoXPlanejamento
+                .Where(x => x.PlanejamentoId == dto.IdPlanejamento && distinctIds.Contains(x.AvaliacaoId))
+                .Select(x => x.AvaliacaoId)
+                .ToListAsync();
+            var setJa = jaVinculados.ToHashSet();
+            foreach (var aid in distinctIds.Where(id => !setJa.Contains(id)))
+            {
+                _contexto.AvaliacaoXPlanejamento.Add(new AvaliacaoXPlanejamento
+                {
+                    AvaliacaoId = aid,
+                    PlanejamentoId = dto.IdPlanejamento
+                });
+            }
+
+            await _contexto.SaveChangesAsync();
+            resposta.Sucesso = true;
+            return resposta;
+        }
     }
 }

--- a/apps/api/appsettings.json
+++ b/apps/api/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Database": {
+    "MaxPoolSize": 20
+  },
   "ConnectionStrings": {
     "AppDbContext": "User Id={USER_ID};Password={DB_PASSWORD};Server={SERVER_URL};Port={PORT_API};Database=postgres"
   },

--- a/apps/mobile/src/app/planejamento/PlanejamentoScreen.tsx
+++ b/apps/mobile/src/app/planejamento/PlanejamentoScreen.tsx
@@ -8,10 +8,10 @@ import {
   atualizarPlanejamento,
   cadastrarPlanejamento,
   buscarPlanejamento,
-  vincularAluno,
-  vincularHabilidade,
-  vincularEstrategia,
-  vincularAvaliacao
+  vincularAlunosLote,
+  vincularHabilidadesLote,
+  vincularEstrategiasLote,
+  vincularAvaliacoesLote
 } from '@src/services/planejamentoService'
 import { buscarEstrategias } from '@src/services/estrategiasService'
 
@@ -346,17 +346,18 @@ export default function PlanejamentoScreen() {
   const toggleAvaliacao = (v: Avaliacao) => toggle(v, selectedAvaliacoes, setSelectedAvaliacoes, v.descricao || 'Avaliação')
   const toggleAluno = (a: Aluno) => toggle(a, selectedAlunos, setSelectedAlunos, a.nomeCompleto || 'Aluno')
 
-  // Vincular apenas os novos
+  // Vincular apenas os novos (uma requisição por tipo — evita saturação de conexões no Postgres)
   const vincularNovos = async <T extends { id?: number }>(
     novos: T[],
     originais: T[],
-    vincularFn: (p: any) => Promise<void>,
-    payloadFn: (item: T & { id: number }) => any
+    planejamentoId: number,
+    loteFn: (idPlanejamento: number, ids: number[]) => Promise<void>
   ) => {
-    const diff = novos
+    const diffIds = novos
       .filter((n): n is T & { id: number } => !!n.id && !originais.some(o => o.id === n.id))
-    if (diff.length > 0) {
-      await Promise.all(diff.map(item => vincularFn(payloadFn(item))))
+      .map(n => n.id)
+    if (diffIds.length > 0) {
+      await loteFn(planejamentoId, diffIds)
     }
   }
 
@@ -396,44 +397,32 @@ export default function PlanejamentoScreen() {
       await vincularNovos(
         selectedEstrategias,
         originalSelectedEstrategias,
-        vincularEstrategia,
-        e => ({
-          idPlanejamento: planejamentoIdFinal,
-          idEstrategia: e.id
-        })
+        planejamentoIdFinal,
+        vincularEstrategiasLote
       )
 
       // Vincular apenas os novos — ALUNOS
       await vincularNovos(
         selectedAlunos,
         originalSelectedAlunos,
-        vincularAluno,
-        a => ({
-          idPlanejamento: planejamentoIdFinal,
-          idAluno: a.id
-        })
+        planejamentoIdFinal,
+        vincularAlunosLote
       )
 
       // Vincular apenas os novos — HABILIDADES
       await vincularNovos(
         selectedHabilidades,
         originalSelectedHabilidades,
-        vincularHabilidade,
-        h => ({
-          idPlanejamento: planejamentoIdFinal,
-          idHabilidade: h.id
-        })
+        planejamentoIdFinal,
+        vincularHabilidadesLote
       )
 
       // Vincular apenas os novos — AVALIAÇÕES
       await vincularNovos(
         selectedAvaliacoes,
         originalSelectedAvaliacoes,
-        vincularAvaliacao,
-        v => ({
-          idPlanejamento: planejamentoIdFinal,
-          idAvaliacao: v.id
-        })
+        planejamentoIdFinal,
+        vincularAvaliacoesLote
       )
 
       showAlert('Sucesso!', `PDI ${isEdit ? 'atualizado' : 'criado'} com sucesso!`, [

--- a/apps/mobile/src/services/planejamentoService.ts
+++ b/apps/mobile/src/services/planejamentoService.ts
@@ -119,12 +119,60 @@ export const vincularAvaliacao = async (payload: {
   idAvaliacao: number
 }): Promise<void> => {
   try {
-    const response = await api.post('Planejamento/vincularavaliacao', payload)
+    const response = await api.post('/Planejamento/vincularavaliacao', payload)
     if (!response.data.sucesso) {
       throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular avaliação')
     }
   } catch (error) {
     console.error('Erro ao vincular avaliação:', error)
+    throw error
+  }
+}
+
+export const vincularAlunosLote = async (idPlanejamento: number, idAlunos: number[]): Promise<void> => {
+  try {
+    const response = await api.post('/Planejamento/vincularalunoslote', { idPlanejamento, idAlunos })
+    if (!response.data.sucesso) {
+      throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular alunos')
+    }
+  } catch (error) {
+    console.error('Erro ao vincular alunos (lote):', error)
+    throw error
+  }
+}
+
+export const vincularHabilidadesLote = async (idPlanejamento: number, idHabilidades: number[]): Promise<void> => {
+  try {
+    const response = await api.post('/Planejamento/vincularhabilidadeslote', { idPlanejamento, idHabilidades })
+    if (!response.data.sucesso) {
+      throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular habilidades')
+    }
+  } catch (error) {
+    console.error('Erro ao vincular habilidades (lote):', error)
+    throw error
+  }
+}
+
+export const vincularEstrategiasLote = async (idPlanejamento: number, idEstrategias: number[]): Promise<void> => {
+  try {
+    const response = await api.post('/Planejamento/vincularestrategiaslote', { idPlanejamento, idEstrategias })
+    if (!response.data.sucesso) {
+      throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular estratégias')
+    }
+  } catch (error) {
+    console.error('Erro ao vincular estratégias (lote):', error)
+    throw error
+  }
+}
+
+export const vincularAvaliacoesLote = async (idPlanejamento: number, idAvaliacoes: number[]): Promise<void> => {
+  try {
+    const response = await api.post('/Planejamento/vincularavaliacoeslote', { idPlanejamento, idAvaliacoes })
+    if (!response.data.sucesso) {
+      throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular avaliações')
+    }
+  } catch (error) {
+    console.error('Erro ao vincular avaliações (lote):', error)
     throw error
   }
 }

--- a/apps/web-app/src/pages/planejamento/PlanejamentosPage.tsx
+++ b/apps/web-app/src/pages/planejamento/PlanejamentosPage.tsx
@@ -7,10 +7,10 @@ import {
   buscarPlanejamento,
   cadastrarPlanejamento,
   excluirPlanejamento,
-  vincularAlunoPlano,
-  vincularHabilidadePlano,
-  vincularEstrategiaPlano,
-  vincularAvaliacaoPlano,
+  vincularAlunosPlanoLote,
+  vincularHabilidadesPlanoLote,
+  vincularEstrategiasPlanoLote,
+  vincularAvaliacoesPlanoLote,
 } from '@/services/planejamentoService'
 import { buscarAlunos } from '@/services/alunoService'
 import { buscarHabilidades } from '@/services/habilidadeService'
@@ -118,12 +118,15 @@ export default function PlanejamentosPage() {
         descicaoPlanejamento: data.descicaoPlanejamento,
       })
 
-      await Promise.all([
-        ...selectedAlunos.map((a) => vincularAlunoPlano(pdi.id, a.id!)),
-        ...selectedHabilidades.map((h) => vincularHabilidadePlano(pdi.id, h.id)),
-        ...selectedEstrategias.map((e) => vincularEstrategiaPlano(pdi.id, e.id)),
-        ...selectedAvaliacoes.map((v) => vincularAvaliacaoPlano(pdi.id, v.id)),
-      ])
+      const idAlunos = selectedAlunos.map((a) => a.id!).filter((id): id is number => id != null)
+      const idHabilidades = selectedHabilidades.map((h) => h.id)
+      const idEstrategias = selectedEstrategias.map((e) => e.id)
+      const idAvaliacoes = selectedAvaliacoes.map((v) => v.id)
+
+      await vincularAlunosPlanoLote(pdi.id, idAlunos)
+      await vincularHabilidadesPlanoLote(pdi.id, idHabilidades)
+      await vincularEstrategiasPlanoLote(pdi.id, idEstrategias)
+      await vincularAvaliacoesPlanoLote(pdi.id, idAvaliacoes)
 
       return pdi
     },

--- a/apps/web-app/src/services/planejamentoService.test.ts
+++ b/apps/web-app/src/services/planejamentoService.test.ts
@@ -9,6 +9,7 @@ import {
   vincularHabilidadePlano,
   vincularEstrategiaPlano,
   vincularAvaliacaoPlano,
+  vincularAlunosPlanoLote,
 } from './planejamentoService'
 import { api } from '@/api/http'
 
@@ -221,6 +222,26 @@ describe('planejamentoService', () => {
       })
 
       await expect(vincularAvaliacaoPlano(1, 1)).rejects.toThrow('Avaliação inválida')
+    })
+  })
+
+  describe('vincularAlunosPlanoLote', () => {
+    it('resolve quando API retorna sucesso', async () => {
+      vi.mocked(api.post).mockResolvedValue({ data: { sucesso: true } })
+
+      await expect(vincularAlunosPlanoLote(5, [1, 2])).resolves.toBeUndefined()
+      expect(api.post).toHaveBeenCalledWith('/Planejamento/vincularalunoslote', {
+        idPlanejamento: 5,
+        idAlunos: [1, 2],
+      })
+    })
+
+    it('lança erro quando API retorna falha', async () => {
+      vi.mocked(api.post).mockResolvedValue({
+        data: { sucesso: false, mensagens: ['Planejamento não encontrado.'] },
+      })
+
+      await expect(vincularAlunosPlanoLote(1, [9])).rejects.toThrow('Planejamento não encontrado.')
     })
   })
 })

--- a/apps/web-app/src/services/planejamentoService.ts
+++ b/apps/web-app/src/services/planejamentoService.ts
@@ -94,3 +94,40 @@ export const vincularAvaliacaoPlano = async (idPlanejamento: number, idAvaliacao
     throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular avaliação')
   }
 }
+
+export const vincularAlunosPlanoLote = async (idPlanejamento: number, idAlunos: number[]) => {
+  const response = await api.post('/Planejamento/vincularalunoslote', { idPlanejamento, idAlunos })
+  if (!response.data.sucesso) {
+    throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular alunos')
+  }
+}
+
+export const vincularHabilidadesPlanoLote = async (idPlanejamento: number, idHabilidades: number[]) => {
+  const response = await api.post('/Planejamento/vincularhabilidadeslote', {
+    idPlanejamento,
+    idHabilidades,
+  })
+  if (!response.data.sucesso) {
+    throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular habilidades')
+  }
+}
+
+export const vincularEstrategiasPlanoLote = async (idPlanejamento: number, idEstrategias: number[]) => {
+  const response = await api.post('/Planejamento/vincularestrategiaslote', {
+    idPlanejamento,
+    idEstrategias,
+  })
+  if (!response.data.sucesso) {
+    throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular estratégias')
+  }
+}
+
+export const vincularAvaliacoesPlanoLote = async (idPlanejamento: number, idAvaliacoes: number[]) => {
+  const response = await api.post('/Planejamento/vincularavaliacoeslote', {
+    idPlanejamento,
+    idAvaliacoes,
+  })
+  if (!response.data.sucesso) {
+    throw new Error(response.data.mensagens?.join(', ') || 'Falha ao vincular avaliações')
+  }
+}

--- a/docs/planejamento-vinculos-lote-e-pool-postgres.md
+++ b/docs/planejamento-vinculos-lote-e-pool-postgres.md
@@ -1,0 +1,68 @@
+# Planejamento: vínculos em lote e limite de pool PostgreSQL
+
+Documento de referência para replicar ou portar estes ajustes quando o novo backend (em stash) for integrado.
+
+## Problema
+
+- Ao criar um **PAEE** com muitos alunos, habilidades, estratégias e critérios, o **web-app** disparava dezenas de `POST` em **paralelo** (`Promise.all`).
+- O PostgreSQL (ex.: Supabase com `max_connections` baixo, ex. 60) retornava **`XX000: Max client connections reached`**, resultando em **500** nos endpoints `vincularhabilidade`, `vincularestrategia`, `vincularavaliacao`, etc.
+- O Npgsql, sem teto explícito, podia competir com o limite global do banco por instância da API.
+
+## Ajustes realizados (backend atual — `apps/api`)
+
+### 1. Limite de pool por instância
+
+- **Arquivos:** `Program.cs`, `appsettings.json` (seção `Database:MaxPoolSize`).
+- **Comportamento:** após montar a connection string, anexa `Maximum Pool Size=<N>` (Npgsql).
+- **Configuração:** `Database:MaxPoolSize` (padrão 20) ou variável de ambiente `Database__MaxPoolSize`.
+- **Regra:** `instâncias da API × N + outros clientes < max_connections` do Postgres (com margem).
+
+### 2. Endpoints em lote (novos)
+
+Rotas POST sob `api/Planejamento/` (mesmo controller e autorização dos demais):
+
+| Rota | Corpo (JSON camelCase) | Observação |
+|------|------------------------|------------|
+| `vincularalunoslote` | `{ idPlanejamento, idAlunos: number[] }` | Lista obrigatória com pelo menos 1 aluno (validação DTO). |
+| `vincularhabilidadeslote` | `{ idPlanejamento, idHabilidades: number[] }` | Lista vazia = sucesso sem alteração. |
+| `vincularestrategiaslote` | `{ idPlanejamento, idEstrategias: number[] }` | Idem. |
+| `vincularavaliacoeslote` | `{ idPlanejamento, idAvaliacoes: number[] }` | Idem. |
+
+**DTOs:** `apps/api/DTOs/Planejamento/PlanejamentoVincular*LoteDTO.cs`
+
+**Serviço:** `PlanejamentoService` — métodos `VincularAlunosEmLote`, `VincularHabilidadesEmLote`, `VincularEstrategiasEmLote`, `VincularAvaliacoesEmLote`:
+
+- Validam se o planejamento pertence ao professor (`IdProfessor`).
+- Validam se todos os IDs informados existem e pertencem à regra de negócio (alunos do professor; demais entidades existentes).
+- **Vínculos já existentes são ignorados** (idempotente), ao contrário do endpoint unitário que falha com “já vinculado”.
+- **Um `SaveChangesAsync` por requisição.**
+
+**Endpoints unitários originais** (`vincularaluno`, `vincularhabilidade`, etc.) foram **mantidos** para compatibilidade (ex.: tela de detalhe que vincula um item por clique).
+
+## Ajustes no web-app (`apps/web-app`)
+
+- **`planejamentoService.ts`:** funções `vincularAlunosPlanoLote`, `vincularHabilidadesPlanoLote`, `vincularEstrategiasPlanoLote`, `vincularAvaliacoesPlanoLote`.
+- **`PlanejamentosPage.tsx`:** após `cadastrarPlanejamento`, chama os quatro lote **em sequência** (não `Promise.all` entre tipos), reduzindo pico de conexões.
+- Testes: `planejamentoService.test.ts` (ex.: `vincularAlunosPlanoLote`).
+
+## Ajustes no mobile (`apps/mobile`)
+
+- **`planejamentoService.ts`:** mesmas rotas de lote; correção da URL de `vincularAvaliacao` para `/Planejamento/vincularavaliacao`.
+- **`PlanejamentoScreen.tsx`:** `vincularNovos` passou a uma **única chamada por tipo** com lista de IDs, em vez de `Promise.all` por item.
+
+## Checklist para o novo backend (stash)
+
+- [ ] Definir **teto de conexão** no cliente SQL (pool) compatível com `max_connections` do Postgres.
+- [ ] Expor as **quatro rotas em lote** com o **mesmo contrato JSON** (nomes de propriedades camelCase) ou atualizar os clients com o novo contrato de forma coordenada.
+- [ ] Replicar regras: dono do planejamento (professor), existência das entidades, comportamento **idempotente** para vínculos duplicados no lote (ou alinhar com produto se preferir falhar).
+- [ ] Manter ou substituir endpoints **unitários** conforme uso nas telas (detalhe x criação em massa).
+- [ ] Após deploy da API, deploy do **web-app** e release do **mobile** que consomem os lote (ordem: API primeiro ou junto).
+
+## Referência rápida de arquivos tocados (monorepo atual)
+
+- `apps/api/Program.cs`, `apps/api/appsettings.json`
+- `apps/api/Controllers/PlanejamentoController.cs`
+- `apps/api/Services/PlanejamentoService.cs`
+- `apps/api/DTOs/Planejamento/PlanejamentoVincular*LoteDTO.cs`
+- `apps/web-app/src/services/planejamentoService.ts`, `PlanejamentosPage.tsx`, `planejamentoService.test.ts`
+- `apps/mobile/src/services/planejamentoService.ts`, `app/planejamento/PlanejamentoScreen.tsx`


### PR DESCRIPTION
- Limita Maximum Pool Size via Database:MaxPoolSize (Program + appsettings)
- Adiciona POST vincular*lote para alunos, habilidades, estratégias e avaliações
- Web-app: Novo PAEE usa 4 chamadas em lote em sequência
- Mobile: vincularNovos usa uma requisição por tipo
- Doc: docs/planejamento-vinculos-lote-e-pool-postgres.md (porta para o novo backend)