### PR TITLE
feat(PAEE): estudos de caso no perfil do aluno e deep link no wizard

### DIFF
--- a/apps/api/Controllers/EstudoDeCasoController.cs
+++ b/apps/api/Controllers/EstudoDeCasoController.cs
@@ -1,0 +1,93 @@
+using api.DTOs.EstudoDeCaso;
+using api.Models;
+using api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace api.Controllers;
+
+[Authorize(Roles = "Professor, Admin")]
+[ApiController]
+[Route("api/[controller]")]
+public class EstudoDeCasoController : ControllerBase
+{
+    private readonly EstudoDeCasoService _service;
+    private readonly UserManager<Usuario> _userManager;
+
+    public EstudoDeCasoController(EstudoDeCasoService service, UserManager<Usuario> userManager)
+    {
+        _service = service;
+        _userManager = userManager;
+    }
+
+    [HttpGet("eixos-catalogo")]
+    public async Task<IActionResult> ListarEixosCatalogo()
+    {
+        var resposta = await _service.ListarEixosCatalogoAsync();
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpGet("por-aluno/{alunoId:int}")]
+    public async Task<IActionResult> ListarPorAluno(int alunoId)
+    {
+        var usuario = await _userManager.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.ListarPorAlunoAsync(alunoId, usuario);
+        if (!resposta.Sucesso)
+            return BadRequest(resposta);
+        return Ok(resposta);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> BuscarPorId(int id)
+    {
+        var usuario = await _userManager.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.BuscarPorIdAsync(id, usuario);
+        if (!resposta.Sucesso)
+        {
+            return resposta.Mensagens.Any(m => m.Contains("não encontrado", StringComparison.OrdinalIgnoreCase))
+                ? NotFound(resposta)
+                : BadRequest(resposta);
+        }
+
+        return Ok(resposta);
+    }
+
+    [HttpPost("cadastro")]
+    public async Task<IActionResult> Cadastrar([FromBody] EstudoDeCasoCadastroDTO dto)
+    {
+        var usuario = await _userManager.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+        var resposta = await _service.CadastrarAsync(dto, usuario);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpPost("{id:int}/gerar-texto-simulado")]
+    public async Task<IActionResult> GerarTextoSimulado(int id)
+    {
+        var usuario = await _userManager.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.GerarTextoSimuladoAsync(id, usuario);
+        if (!resposta.Sucesso)
+        {
+            return resposta.Mensagens.Any(m => m.Contains("não encontrado", StringComparison.OrdinalIgnoreCase))
+                ? NotFound(resposta)
+                : BadRequest(resposta);
+        }
+
+        return Ok(resposta);
+    }
+}

--- a/apps/api/DTOs/EstudoDeCaso/EstudoDeCasoDTO.cs
+++ b/apps/api/DTOs/EstudoDeCaso/EstudoDeCasoDTO.cs
@@ -1,0 +1,51 @@
+namespace api.DTOs.EstudoDeCaso;
+
+public class EstudoDeCasoEixoCatalogoDTO
+{
+    public int Id { get; set; }
+    public string Codigo { get; set; } = string.Empty;
+    public string Rotulo { get; set; } = string.Empty;
+    public string? DescricaoHint { get; set; }
+    public int OrdemExibicao { get; set; }
+}
+
+public class EstudoDeCasoItemEixoDTO
+{
+    public int EixoCatalogoId { get; set; }
+    public string? Anotacao { get; set; }
+}
+
+public class EstudoDeCasoCadastroDTO
+{
+    public int AlunoId { get; set; }
+    public string Titulo { get; set; } = string.Empty;
+    public string ContextoSituacao { get; set; } = string.Empty;
+    public List<EstudoDeCasoItemEixoDTO> ItensEixo { get; set; } = new();
+}
+
+public class EstudoDeCasoItemDetalheDTO : EstudoDeCasoItemEixoDTO
+{
+    public string CodigoEixo { get; set; } = string.Empty;
+    public string RotuloEixo { get; set; } = string.Empty;
+}
+
+public class EstudoDeCasoDetalheDTO
+{
+    public int Id { get; set; }
+    public int AlunoId { get; set; }
+    public string AlunoNomeCompleto { get; set; } = string.Empty;
+    public string Titulo { get; set; } = string.Empty;
+    public string ContextoSituacao { get; set; } = string.Empty;
+    public string? TextoSimulado { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public List<EstudoDeCasoItemDetalheDTO> ItensEixo { get; set; } = new();
+}
+
+public class EstudoDeCasoListaItemDTO
+{
+    public int Id { get; set; }
+    public string Titulo { get; set; } = string.Empty;
+    public DateTime UpdatedAt { get; set; }
+    public bool PossuiTextoSimulado { get; set; }
+}

--- a/apps/api/Data/AppDbContext.cs
+++ b/apps/api/Data/AppDbContext.cs
@@ -34,6 +34,9 @@ namespace Data
         public DbSet<DesempenhoAtividade> DesempenhosAtividades { get; set; }
         public DbSet<ObservacaoAlunoAvaliacaoHistorico> ObservacoesAlunosAvaliacaoHistorico { get; set; }
         public DbSet<DiagnosticoFinal> DiagnosticosFinais { get; set; }
+        public DbSet<EstudoDeCasoEixoCatalogo> EstudoCasoEixosCatalogo { get; set; }
+        public DbSet<EstudoDeCaso> EstudosCaso { get; set; }
+        public DbSet<EstudoDeCasoItemEixo> EstudoCasoItensEixo { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -198,6 +201,38 @@ namespace Data
 
             modelBuilder.Entity<ObservacaoAlunoAvaliacaoHistorico>()
                 .HasIndex(o => new { o.AvaliacaoDiagnosticaId, o.AlunoId, o.DataRegistro });
+
+            modelBuilder.Entity<EstudoDeCasoEixoCatalogo>()
+                .HasIndex(e => e.Codigo)
+                .IsUnique();
+
+            modelBuilder.Entity<EstudoDeCasoItemEixo>()
+                .HasIndex(i => new { i.EstudoDeCasoId, i.EixoCatalogoId })
+                .IsUnique();
+
+            modelBuilder.Entity<EstudoDeCaso>()
+                .HasOne(e => e.Aluno)
+                .WithMany()
+                .HasForeignKey(e => e.AlunoId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<EstudoDeCaso>()
+                .HasOne(e => e.Professor)
+                .WithMany()
+                .HasForeignKey(e => e.ProfessorId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<EstudoDeCasoItemEixo>()
+                .HasOne(i => i.EstudoDeCaso)
+                .WithMany(e => e.ItensEixo)
+                .HasForeignKey(i => i.EstudoDeCasoId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<EstudoDeCasoItemEixo>()
+                .HasOne(i => i.CatalogoEixo)
+                .WithMany(c => c.Itens)
+                .HasForeignKey(i => i.EixoCatalogoId)
+                .OnDelete(DeleteBehavior.Restrict);
 
         }
 

--- a/apps/api/Migrations/20260518005435_EstudosCasoPaeeFase3.Designer.cs
+++ b/apps/api/Migrations/20260518005435_EstudosCasoPaeeFase3.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260518005435_EstudosCasoPaeeFase3")]
+    partial class EstudosCasoPaeeFase3
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/Migrations/20260518005435_EstudosCasoPaeeFase3.cs
+++ b/apps/api/Migrations/20260518005435_EstudosCasoPaeeFase3.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class EstudosCasoPaeeFase3 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "estudo_caso_eixos_catalogo",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    codigo = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    rotulo = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: false),
+                    descricaohint = table.Column<string>(type: "text", nullable: true),
+                    ordemexibicao = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_estudo_caso_eixos_catalogo", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "estudos_caso",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    alunoid = table.Column<int>(type: "integer", nullable: false),
+                    professorid = table.Column<int>(type: "integer", nullable: false),
+                    titulo = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    contextosituacao = table.Column<string>(type: "text", nullable: true),
+                    textosimulado = table.Column<string>(type: "text", nullable: true),
+                    createdat = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updatedat = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_estudos_caso", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_estudos_caso_alunos_alunoid",
+                        column: x => x.alunoid,
+                        principalTable: "alunos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_estudos_caso_professores_professorid",
+                        column: x => x.professorid,
+                        principalTable: "professores",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "estudo_caso_itens_eixo",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    estudodecasoid = table.Column<int>(type: "integer", nullable: false),
+                    eixocatalogoid = table.Column<int>(type: "integer", nullable: false),
+                    anotacao = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_estudo_caso_itens_eixo", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_estudo_caso_itens_eixo_estudo_caso_eixos_catalogo_eixocatal~",
+                        column: x => x.eixocatalogoid,
+                        principalTable: "estudo_caso_eixos_catalogo",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_estudo_caso_itens_eixo_estudos_caso_estudodecasoid",
+                        column: x => x.estudodecasoid,
+                        principalTable: "estudos_caso",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_estudo_caso_eixos_catalogo_codigo",
+                table: "estudo_caso_eixos_catalogo",
+                column: "codigo",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_estudo_caso_itens_eixo_eixocatalogoid",
+                table: "estudo_caso_itens_eixo",
+                column: "eixocatalogoid");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_estudo_caso_itens_eixo_estudodecasoid_eixocatalogoid",
+                table: "estudo_caso_itens_eixo",
+                columns: new[] { "estudodecasoid", "eixocatalogoid" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_estudos_caso_alunoid",
+                table: "estudos_caso",
+                column: "alunoid");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_estudos_caso_professorid",
+                table: "estudos_caso",
+                column: "professorid");
+
+            migrationBuilder.Sql(
+                """
+                INSERT INTO estudo_caso_eixos_catalogo (codigo, rotulo, descricaohint, ordemexibicao) VALUES
+                ('COMUNICACAO', 'Comunicação e linguagem', 'Compreensão, expressão oral e escrita; uso de AAC quando aplicável.', 1),
+                ('COGNICAO', 'Cognição e aprendizagem', 'Atenção, memória, raciocínio e estratégias de estudo.', 2),
+                ('SOCIOEMOCIONAL', 'Aspectos socioemocionais', 'Regulação afetiva, interação social e pertencimento.', 3),
+                ('AUTONOMIA', 'Autonomia e vida diária', 'Independência funcional, autocuidado e organização.', 4),
+                ('FAMILIA_ESCOLA', 'Articulação família-escola-comunidade', 'Participação familiar e alinhamento de metas.', 5),
+                ('CURRICULO', 'Currículo e participação', 'Acesso ao currículo com adaptações razoáveis e CMLO.', 6)
+                ON CONFLICT (codigo) DO NOTHING;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "estudo_caso_itens_eixo");
+
+            migrationBuilder.DropTable(
+                name: "estudos_caso");
+
+            migrationBuilder.DropTable(
+                name: "estudo_caso_eixos_catalogo");
+        }
+    }
+}

--- a/apps/api/Models/EstudoDeCaso.cs
+++ b/apps/api/Models/EstudoDeCaso.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace api.Models;
+
+/// <summary>Estudo de caso vinculado ao aluno para sustentar planejamento PAEE.</summary>
+[Table("estudos_caso")]
+public class EstudoDeCaso
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int AlunoId { get; set; }
+
+    /// <summary>Professor proprietário (espelha aluno.IdProfessor para consultas rápidas).</summary>
+    public int ProfessorId { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string Titulo { get; set; } = string.Empty;
+
+    [Column(TypeName = "text")]
+    public string ContextoSituacao { get; set; } = string.Empty;
+
+    /// <summary>Rascunho gerado automaticamente (simulação — revisão humana obrigatória).</summary>
+    [Column(TypeName = "text")]
+    public string? TextoSimulado { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    [ForeignKey(nameof(AlunoId))]
+    public Aluno Aluno { get; set; } = null!;
+
+    [ForeignKey(nameof(ProfessorId))]
+    public Professor Professor { get; set; } = null!;
+
+    public ICollection<EstudoDeCasoItemEixo> ItensEixo { get; set; } = new List<EstudoDeCasoItemEixo>();
+}

--- a/apps/api/Models/EstudoDeCasoEixoCatalogo.cs
+++ b/apps/api/Models/EstudoDeCasoEixoCatalogo.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace api.Models;
+
+/// <summary>Eixos pedagógicos padrão para orientar o estudo de caso (seed).</summary>
+[Table("estudo_caso_eixos_catalogo")]
+public class EstudoDeCasoEixoCatalogo
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(50)]
+    public string Codigo { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(160)]
+    public string Rotulo { get; set; } = string.Empty;
+
+    [Column(TypeName = "text")]
+    public string? DescricaoHint { get; set; }
+
+    public int OrdemExibicao { get; set; }
+
+    public ICollection<EstudoDeCasoItemEixo> Itens { get; set; } = new List<EstudoDeCasoItemEixo>();
+}

--- a/apps/api/Models/EstudoDeCasoItemEixo.cs
+++ b/apps/api/Models/EstudoDeCasoItemEixo.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace api.Models;
+
+[Table("estudo_caso_itens_eixo")]
+public class EstudoDeCasoItemEixo
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int EstudoDeCasoId { get; set; }
+
+    public int EixoCatalogoId { get; set; }
+
+    [Column(TypeName = "text")]
+    public string? Anotacao { get; set; }
+
+    [ForeignKey(nameof(EstudoDeCasoId))]
+    public EstudoDeCaso EstudoDeCaso { get; set; } = null!;
+
+    [ForeignKey(nameof(EixoCatalogoId))]
+    public EstudoDeCasoEixoCatalogo CatalogoEixo { get; set; } = null!;
+}

--- a/apps/api/Program.cs
+++ b/apps/api/Program.cs
@@ -157,6 +157,7 @@ builder.Services.AddScoped<AvaliacaoService>();
 builder.Services.AddHttpClient();
 builder.Services.AddScoped<HotmartService>();
 builder.Services.AddScoped<AvaliacaoDiagnosticaService>();
+builder.Services.AddScoped<EstudoDeCasoService>();
 builder.Services.AddScoped<AdminService>();
 builder.Services.AddScoped<AtividadeService>();
 builder.Services.AddScoped<EmailService>();

--- a/apps/api/Services/EstudoDeCasoService.cs
+++ b/apps/api/Services/EstudoDeCasoService.cs
@@ -1,0 +1,317 @@
+using api.DTOs.EstudoDeCaso;
+using api.Models;
+using api.Responses;
+using Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Services;
+
+public class EstudoDeCasoService
+{
+    private readonly AppDbContext _db;
+
+    public EstudoDeCasoService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<ServiceResponse<EstudoDeCasoEixoCatalogoDTO>> ListarEixosCatalogoAsync()
+    {
+        var r = new ServiceResponse<EstudoDeCasoEixoCatalogoDTO>();
+        try
+        {
+            var lista = await _db.EstudoCasoEixosCatalogo
+                .AsNoTracking()
+                .OrderBy(e => e.OrdemExibicao)
+                .ThenBy(e => e.Id)
+                .Select(e => new EstudoDeCasoEixoCatalogoDTO
+                {
+                    Id = e.Id,
+                    Codigo = e.Codigo,
+                    Rotulo = e.Rotulo,
+                    DescricaoHint = e.DescricaoHint,
+                    OrdemExibicao = e.OrdemExibicao,
+                })
+                .ToListAsync();
+
+            r.ListaObjetos = lista;
+            r.Sucesso = true;
+            return r;
+        }
+        catch (Exception ex)
+        {
+            r.SetFalha($"Erro ao listar eixos: {ex.Message}");
+            return r;
+        }
+    }
+
+    public async Task<ServiceResponse<EstudoDeCasoListaItemDTO>> ListarPorAlunoAsync(int alunoId, Usuario usuario)
+    {
+        var r = new ServiceResponse<EstudoDeCasoListaItemDTO>();
+        var pid = usuario.ProfessorId ?? 0;
+        if (pid == 0)
+        {
+            r.SetFalha("Professor não vinculado ao usuário.");
+            return r;
+        }
+
+        var alunoOk = await _db.Alunos.AsNoTracking().AnyAsync(a => a.Id == alunoId && a.IdProfessor == pid);
+        if (!alunoOk)
+        {
+            r.SetFalha("Aluno não encontrado ou sem permissão.");
+            return r;
+        }
+
+        try
+        {
+            var lista = await _db.EstudosCaso
+                .AsNoTracking()
+                .Where(c => c.AlunoId == alunoId && c.ProfessorId == pid)
+                .OrderByDescending(c => c.UpdatedAt)
+                .Select(c => new EstudoDeCasoListaItemDTO
+                {
+                    Id = c.Id,
+                    Titulo = c.Titulo,
+                    UpdatedAt = c.UpdatedAt,
+                    PossuiTextoSimulado = c.TextoSimulado != null && c.TextoSimulado.Trim().Length > 0,
+                })
+                .ToListAsync();
+
+            r.ListaObjetos = lista;
+            r.Sucesso = true;
+            return r;
+        }
+        catch (Exception ex)
+        {
+            r.SetFalha($"Erro ao listar estudos de caso: {ex.Message}");
+            return r;
+        }
+    }
+
+    public async Task<ServiceResponse<EstudoDeCasoDetalheDTO>> BuscarPorIdAsync(int id, Usuario usuario)
+    {
+        var r = new ServiceResponse<EstudoDeCasoDetalheDTO>();
+        var pid = usuario.ProfessorId ?? 0;
+        if (pid == 0)
+        {
+            r.SetFalha("Professor não vinculado ao usuário.");
+            return r;
+        }
+
+        try
+        {
+            var entity = await _db.EstudosCaso
+                .AsNoTracking()
+                .Include(c => c.Aluno)
+                .Include(c => c.ItensEixo)
+                .ThenInclude(i => i.CatalogoEixo)
+                .FirstOrDefaultAsync(c => c.Id == id && c.ProfessorId == pid);
+
+            if (entity == null)
+            {
+                r.SetFalha("Estudo de caso não encontrado.");
+                return r;
+            }
+
+            r.AdicionaObjeto(MapearDetalhe(entity));
+            r.Sucesso = true;
+            return r;
+        }
+        catch (Exception ex)
+        {
+            r.SetFalha($"Erro ao buscar estudo de caso: {ex.Message}");
+            return r;
+        }
+    }
+
+    public async Task<ServiceResponse<EstudoDeCasoDetalheDTO>> CadastrarAsync(EstudoDeCasoCadastroDTO dto, Usuario usuario)
+    {
+        var r = new ServiceResponse<EstudoDeCasoDetalheDTO>();
+        var pid = usuario.ProfessorId ?? 0;
+        if (pid == 0)
+        {
+            r.SetFalha("Professor não vinculado ao usuário.");
+            return r;
+        }
+
+        if (string.IsNullOrWhiteSpace(dto.Titulo) || string.IsNullOrWhiteSpace(dto.ContextoSituacao))
+        {
+            r.SetFalha("Título e contexto da situação são obrigatórios.");
+            return r;
+        }
+
+        var aluno = await _db.Alunos.FirstOrDefaultAsync(a => a.Id == dto.AlunoId && a.IdProfessor == pid);
+        if (aluno == null)
+        {
+            r.SetFalha("Aluno não encontrado ou sem permissão.");
+            return r;
+        }
+
+        var idsEixo = dto.ItensEixo.Select(i => i.EixoCatalogoId).Distinct().ToList();
+        if (idsEixo.Count == 0)
+        {
+            r.SetFalha("Selecione pelo menos um eixo pedagógico.");
+            return r;
+        }
+
+        var existentes = await _db.EstudoCasoEixosCatalogo.Where(e => idsEixo.Contains(e.Id)).Select(e => e.Id).ToListAsync();
+        if (existentes.Count != idsEixo.Count)
+        {
+            r.SetFalha("Um ou mais eixos informados são inválidos.");
+            return r;
+        }
+
+        try
+        {
+            var now = DateTime.UtcNow;
+            var caso = new EstudoDeCaso
+            {
+                AlunoId = dto.AlunoId,
+                ProfessorId = pid,
+                Titulo = dto.Titulo.Trim(),
+                ContextoSituacao = dto.ContextoSituacao.Trim(),
+                TextoSimulado = null,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+
+            foreach (var item in dto.ItensEixo.GroupBy(i => i.EixoCatalogoId).Select(g => g.First()))
+            {
+                caso.ItensEixo.Add(new EstudoDeCasoItemEixo
+                {
+                    EixoCatalogoId = item.EixoCatalogoId,
+                    Anotacao = string.IsNullOrWhiteSpace(item.Anotacao) ? null : item.Anotacao.Trim(),
+                });
+            }
+
+            _db.EstudosCaso.Add(caso);
+            await _db.SaveChangesAsync();
+
+            var carregado = await _db.EstudosCaso
+                .AsNoTracking()
+                .Include(c => c.Aluno)
+                .Include(c => c.ItensEixo)
+                .ThenInclude(i => i.CatalogoEixo)
+                .FirstAsync(c => c.Id == caso.Id);
+
+            r.AdicionaObjeto(MapearDetalhe(carregado));
+            r.AdicionaMensagem("Estudo de caso registrado com sucesso.");
+            r.Sucesso = true;
+            return r;
+        }
+        catch (Exception ex)
+        {
+            r.SetFalha($"Erro ao salvar estudo de caso: {ex.Message}");
+            return r;
+        }
+    }
+
+    public async Task<ServiceResponse<EstudoDeCasoDetalheDTO>> GerarTextoSimuladoAsync(int id, Usuario usuario)
+    {
+        var r = new ServiceResponse<EstudoDeCasoDetalheDTO>();
+        var pid = usuario.ProfessorId ?? 0;
+        if (pid == 0)
+        {
+            r.SetFalha("Professor não vinculado ao usuário.");
+            return r;
+        }
+
+        try
+        {
+            var entity = await _db.EstudosCaso
+                .Include(c => c.Aluno)
+                .Include(c => c.ItensEixo)
+                .ThenInclude(i => i.CatalogoEixo)
+                .FirstOrDefaultAsync(c => c.Id == id && c.ProfessorId == pid);
+
+            if (entity == null)
+            {
+                r.SetFalha("Estudo de caso não encontrado.");
+                return r;
+            }
+
+            entity.TextoSimulado = MontarTextoSimulado(entity);
+            entity.UpdatedAt = DateTime.UtcNow;
+            await _db.SaveChangesAsync();
+
+            var dto = MapearDetalhe(entity);
+            r.AdicionaObjeto(dto);
+            r.AdicionaMensagem("Texto simulado gerado. Revise antes de usar em documentos oficiais.");
+            r.Sucesso = true;
+            return r;
+        }
+        catch (Exception ex)
+        {
+            r.SetFalha($"Erro ao gerar texto simulado: {ex.Message}");
+            return r;
+        }
+    }
+
+    private static EstudoDeCasoDetalheDTO MapearDetalhe(EstudoDeCaso entity)
+    {
+        return new EstudoDeCasoDetalheDTO
+        {
+            Id = entity.Id,
+            AlunoId = entity.AlunoId,
+            AlunoNomeCompleto = entity.Aluno?.NomeCompleto ?? "",
+            Titulo = entity.Titulo,
+            ContextoSituacao = entity.ContextoSituacao,
+            TextoSimulado = entity.TextoSimulado,
+            CreatedAt = entity.CreatedAt,
+            UpdatedAt = entity.UpdatedAt,
+            ItensEixo = entity.ItensEixo
+                .OrderBy(i => i.CatalogoEixo?.OrdemExibicao ?? 0)
+                .Select(i => new EstudoDeCasoItemDetalheDTO
+                {
+                    EixoCatalogoId = i.EixoCatalogoId,
+                    Anotacao = i.Anotacao,
+                    CodigoEixo = i.CatalogoEixo?.Codigo ?? "",
+                    RotuloEixo = i.CatalogoEixo?.Rotulo ?? "",
+                })
+                .ToList(),
+        };
+    }
+
+    private static string MontarTextoSimulado(EstudoDeCaso entity)
+    {
+        var nome = entity.Aluno?.NomeCompleto?.Trim() ?? "Aluno";
+        var idadeTxt = "";
+        if (entity.Aluno?.DataNascimento is { } dn)
+        {
+            var hoje = DateOnly.FromDateTime(DateTime.UtcNow);
+            var anos = hoje.Year - dn.Year - (hoje.DayOfYear < dn.DayOfYear ? 1 : 0);
+            if (anos >= 0 && anos < 130)
+                idadeTxt = $" Idade cronológica aproximada: {anos} anos.";
+        }
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("*** TEXTO SIMULADO (RASCUNHO AUTOMÁTICO — REVISÃO PEDAGÓGICA OBRIGATÓRIA) ***");
+        sb.AppendLine();
+        sb.AppendLine($"Estudo de caso — {entity.Titulo.Trim()}");
+        sb.AppendLine($"Aluno(a): {nome}.{idadeTxt}");
+        sb.AppendLine($"Gerado em (UTC): {DateTime.UtcNow:yyyy-MM-dd HH:mm}");
+        sb.AppendLine();
+        sb.AppendLine("--- Contexto relatado pela equipe ---");
+        sb.AppendLine(entity.ContextoSituacao.Trim());
+        sb.AppendLine();
+        sb.AppendLine("--- Recorte por eixos (orientação para PAEE) ---");
+
+        foreach (var item in entity.ItensEixo.OrderBy(i => i.CatalogoEixo?.OrdemExibicao ?? 0))
+        {
+            var rotulo = item.CatalogoEixo?.Rotulo ?? $"Eixo #{item.EixoCatalogoId}";
+            sb.AppendLine();
+            sb.AppendLine($"• {rotulo}");
+            if (!string.IsNullOrWhiteSpace(item.CatalogoEixo?.DescricaoHint))
+                sb.AppendLine($"  Referência: {item.CatalogoEixo.DescricaoHint.Trim()}");
+            if (!string.IsNullOrWhiteSpace(item.Anotacao))
+                sb.AppendLine($"  Observação registrada: {item.Anotacao.Trim()}");
+            sb.AppendLine($"  Sugestão de análise (simulada): relacionar indicadores observados em sala/atendimento com demandas de mediação e metas próximas do ciclo PAEE, priorizando coerência com o perfil do(a) estudante.");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("--- Encerramento ---");
+        sb.AppendLine("Este texto não substitui avaliação clínica nem parecer especializado: utilize como ponto de partida para discussão em equipe e adequação ao currículo.");
+
+        return sb.ToString();
+    }
+}

--- a/apps/mobile/src/types/avaliacao-diagnostica.ts
+++ b/apps/mobile/src/types/avaliacao-diagnostica.ts
@@ -9,6 +9,13 @@ export type NivelRealizacao =
   | 'NaoRealizou'        // Não conseguiu realizar
   | 'NaoAvaliado';       // Ainda não avaliado
 
+/** Perfil agregado (substitui percentual numérico legado em diagnósticos persistidos). */
+export type NivelPerfilAutonomia =
+  | 'NaoAvaliado'
+  | 'PredominioDependencia'
+  | 'AutonomiaMediada'
+  | 'PredominioAutonomia';
+
 /**
  * Resumo de uma avaliação diagnóstica (usado na lista "Minhas Avaliações")
  */
@@ -56,6 +63,14 @@ export interface AvaliacaoDiagnosticaDetalhada {
   concluida: boolean;
   createdAt?: string;
   updatedAt?: string;
+  perfisAutonomiaPorAluno?: Array<{
+    alunoId: number;
+    nomeCompleto: string;
+    nivelPerfilAutonomia: NivelPerfilAutonomia | string;
+    rotuloExibicao: string;
+    sugestaoPaee: string;
+    percentualAutonomiaCalculado?: number | null;
+  }>;
 }
 
 /**
@@ -126,7 +141,7 @@ export interface DiagnosticoFinal {
     nomeCompleto: string;
   };
   resumo: string;                        // ex: "Dificuldade moderada em reconhecimento de letras"
-  percentualAutonomia: number;           // 0 a 100
+  nivelPerfilAutonomia: NivelPerfilAutonomia | string;
   recomendacoes: string;
   habilidadesFortes?: string;
   habilidadesAReenforcar?: string;
@@ -141,7 +156,8 @@ export interface DiagnosticoFinal {
 export interface DiagnosticoResumo {
   id: number;
   alunoNome: string;
-  percentualAutonomia: number;
+  nivelPerfilAutonomia: NivelPerfilAutonomia | string;
+  rotuloExibicao?: string;
   resumoCurto: string;
   geradoEm: string;
 }

--- a/apps/web-app/src/components/layout/Sidebar.tsx
+++ b/apps/web-app/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   Users,
   BookOpen,
   ClipboardText,
+  Article,
   SignOut,
   List,
   X,
@@ -24,6 +25,7 @@ const navItems = [
   { to: '/alunos', icon: Users, label: 'Alunos' },
   { to: '/planejamentos', icon: BookOpen, label: 'PAEE' },
   { to: '/avaliacoes', icon: ClipboardText, label: 'Avaliações' },
+  { to: '/estudo-caso/nova/aluno', icon: Article, label: 'Estudo de caso' },
 ]
 
 interface SidebarProps {

--- a/apps/web-app/src/pages/aluno/AlunoProfilePage.tsx
+++ b/apps/web-app/src/pages/aluno/AlunoProfilePage.tsx
@@ -13,11 +13,13 @@ import {
   Trash,
   CalendarBlank,
   Clock,
+  Article,
 } from '@phosphor-icons/react'
 import { AlignmentType, Document, Packer, Paragraph, TextRun } from 'docx'
 import { buscarAlunoPorId, excluirAluno } from '@/services/alunoService'
 import { buscarEscolasProfessor } from '@/services/professorService'
 import { buscarAvaliacaoPorId, buscarAvaliacoesDiagnosticas, gerarPdfBlob } from '@/services/avaliacaoDiagnosticaService'
+import { listarEstudosCasoPorAluno } from '@/services/estudoCasoService'
 import { PageHeader } from '@/components/common/PageHeader'
 import { SkeletonList } from '@/components/common/SkeletonCard'
 import { Button } from '@/components/ui/button'
@@ -25,6 +27,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import type { PlanejamentoAluno } from '@/types/planejamento'
+import { EstudoCasoDetalheDialog } from '@/pages/estudo-caso/EstudoCasoDetalheDialog'
 import { AlunoFormDialog } from './AlunoFormDialog'
 import { AlunoExcluirDialog } from './AlunoExcluirDialog'
 import { useToast } from '@/hooks/useToast'
@@ -38,6 +41,7 @@ export default function AlunoProfilePage() {
   const { success, error: showError } = useToast()
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [estudoCasoDetalheId, setEstudoCasoDetalheId] = useState<number | null>(null)
 
   const { data: aluno, isLoading } = useQuery({
     queryKey: ['aluno', id],
@@ -59,6 +63,12 @@ export default function AlunoProfilePage() {
     queryFn: async () => Promise.all(
       avaliacoesDiagnosticasResumo.map((av) => buscarAvaliacaoPorId(av.id))
     ),
+  })
+
+  const { data: estudosCaso = [], isLoading: loadingEstudosCaso } = useQuery({
+    queryKey: ['estudos-caso-aluno', aluno?.id],
+    queryFn: () => listarEstudosCasoPorAluno(aluno!.id!),
+    enabled: !!aluno?.id,
   })
 
   const deleteMutation = useMutation({
@@ -452,6 +462,52 @@ export default function AlunoProfilePage() {
           </Card>
         )}
 
+        {/* Estudos de caso (PAEE) */}
+        <Card>
+          <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-2 space-y-0">
+            <CardTitle className="flex items-center gap-2">
+              <Article size={20} />
+              Estudos de caso
+            </CardTitle>
+            <Button size="sm" variant="outline" onClick={() => navigate(`/estudo-caso/nova/aluno?alunoId=${alunoId}`)}>
+              <ArrowSquareOut size={14} />
+              Novo estudo
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {loadingEstudosCaso ? (
+              <p className="text-sm text-muted-foreground">Carregando estudos de caso…</p>
+            ) : estudosCaso.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Nenhum estudo de caso registrado para este aluno. Use &quot;Novo estudo&quot; para iniciar o assistente.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {estudosCaso.map((ec) => (
+                  <div key={ec.id} className="flex flex-wrap items-center justify-between gap-2 p-3 rounded-lg bg-muted">
+                    <div className="min-w-0 flex-1">
+                      <p className="font-semibold text-sm text-foreground truncate">{ec.titulo}</p>
+                      <p className="text-xs text-muted-foreground">
+                        Atualizado em {new Date(ec.updatedAt).toLocaleString('pt-BR')}
+                      </p>
+                      <div className="flex gap-2 mt-1 flex-wrap">
+                        {ec.possuiTextoSimulado ? (
+                          <Badge variant="secondary">Rascunho disponível</Badge>
+                        ) : (
+                          <Badge variant="outline">Sem rascunho automático</Badge>
+                        )}
+                      </div>
+                    </div>
+                    <Button size="sm" variant="outline" onClick={() => setEstudoCasoDetalheId(ec.id)}>
+                      Ver detalhes
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
         {/* Avaliação Diagnóstica */}
         {loadingAvaliacoesDiagnosticas ? (
           <Card>
@@ -497,6 +553,14 @@ export default function AlunoProfilePage() {
 
 
       </motion.div>
+
+      <EstudoCasoDetalheDialog
+        open={estudoCasoDetalheId != null}
+        onOpenChange={(open) => {
+          if (!open) setEstudoCasoDetalheId(null)
+        }}
+        estudoId={estudoCasoDetalheId}
+      />
 
       <AlunoFormDialog
         open={editOpen}

--- a/apps/web-app/src/pages/avaliacao/AvaliacaoDesempenhoPage.tsx
+++ b/apps/web-app/src/pages/avaliacao/AvaliacaoDesempenhoPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ClockCounterClockwise, FloppyDisk } from '@phosphor-icons/react'
+import { ClockCounterClockwise, FloppyDisk, LightbulbFilament } from '@phosphor-icons/react'
 import { PageHeader } from '@/components/common/PageHeader'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -56,6 +56,13 @@ export default function AvaliacaoDesempenhoPage() {
     }
     return m
   }, [habilidades])
+
+  const perfisOrdenados = useMemo(() => {
+    const lista = avaliacao?.perfisAutonomiaPorAluno ?? []
+    return [...lista].sort((a, b) =>
+      (a.nomeCompleto || '').localeCompare(b.nomeCompleto || '', 'pt-BR', { sensitivity: 'base' })
+    )
+  }, [avaliacao?.perfisAutonomiaPorAluno])
 
   useEffect(() => {
     if (!avaliacao) return
@@ -181,6 +188,46 @@ export default function AvaliacaoDesempenhoPage() {
       <p className="text-sm text-muted-foreground">
         Você pode continuar lançando e editando desempenho mesmo após concluir a avaliação.
       </p>
+
+      {perfisOrdenados.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Perfil de autonomia e PAEE</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              Visão geral calculada a partir dos níveis já lançados por atividade (Autonomia, Com ajuda, Não realizou).
+              Atualiza quando você salva e ao recarregar esta tela.
+            </p>
+            <div className="space-y-3">
+              {perfisOrdenados.map((p) => {
+                const pct =
+                  typeof p.percentualAutonomiaCalculado === 'number'
+                    ? `${p.percentualAutonomiaCalculado.toLocaleString('pt-BR', { maximumFractionDigits: 1 })}% nas atividades já avaliadas`
+                    : null
+                return (
+                  <div
+                    key={p.alunoId}
+                    className="rounded-lg border border-border bg-muted/35 px-3 py-3 space-y-2"
+                  >
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{p.nomeCompleto}</p>
+                      {pct && (
+                        <p className="text-xs text-muted-foreground mt-0.5">{pct}</p>
+                      )}
+                    </div>
+                    <p className="text-sm text-foreground leading-snug">{p.rotuloExibicao}</p>
+                    <p className="text-xs text-muted-foreground flex gap-2 leading-snug">
+                      <LightbulbFilament size={16} className="shrink-0 text-amber-600 mt-0.5" aria-hidden />
+                      <span>{p.sugestaoPaee}</span>
+                    </p>
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {alunos.length === 0 || atividades.length === 0 ? (
         <Card>

--- a/apps/web-app/src/pages/estudo-caso/EstudoCasoDetalheDialog.tsx
+++ b/apps/web-app/src/pages/estudo-caso/EstudoCasoDetalheDialog.tsx
@@ -1,0 +1,139 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Copy } from '@phosphor-icons/react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useToast } from '@/hooks/useToast'
+import { formatFriendlyErrorBody, getApiErrorFeedback } from '@/lib/apiFriendlyError'
+import { buscarEstudoCasoPorId, gerarTextoSimuladoEstudoCaso } from '@/services/estudoCasoService'
+
+interface EstudoCasoDetalheDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  estudoId: number | null
+}
+
+export function EstudoCasoDetalheDialog({ open, onOpenChange, estudoId }: EstudoCasoDetalheDialogProps) {
+  const qc = useQueryClient()
+  const { success, error: showError } = useToast()
+
+  const {
+    data: detalhe,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['estudo-caso', estudoId],
+    queryFn: () => buscarEstudoCasoPorId(estudoId!),
+    enabled: open && estudoId != null && estudoId > 0,
+  })
+
+  const gerarMutation = useMutation({
+    mutationFn: () => gerarTextoSimuladoEstudoCaso(estudoId!),
+    onSuccess: (d) => {
+      qc.setQueryData(['estudo-caso', estudoId], d)
+      qc.invalidateQueries({ queryKey: ['estudos-caso-aluno', d.alunoId] })
+      success('Rascunho gerado', 'Revise o texto antes de usar oficialmente.')
+    },
+    onError: (err: unknown) => {
+      const fb = getApiErrorFeedback(err)
+      showError(fb.title, formatFriendlyErrorBody(fb))
+    },
+  })
+
+  async function copiarTexto() {
+    const t = detalhe?.textoSimulado?.trim()
+    if (!t) return
+    try {
+      await navigator.clipboard.writeText(t)
+      success('Copiado', 'Texto enviado para a área de transferência.')
+    } catch {
+      showError('Não foi possível copiar', 'Seu navegador pode ter bloqueado o acesso à área de transferência.')
+    }
+  }
+
+  const feedbackErro =
+    isError && error instanceof Error ? error.message : isError ? 'Não foi possível carregar o estudo de caso.' : null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto gap-3">
+        <DialogHeader>
+          <DialogTitle>{detalhe?.titulo ?? 'Estudo de caso'}</DialogTitle>
+          <DialogDescription>
+            Conteúdo de apoio ao PAEE. Texto automático é marcado como <strong>rascunho simulado</strong> e exige revisão.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && <p className="text-sm text-muted-foreground">Carregando…</p>}
+        {feedbackErro && <p className="text-sm text-destructive">{feedbackErro}</p>}
+
+        {detalhe && (
+          <div className="space-y-4 text-sm">
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Contexto / situação</p>
+              <p className="text-foreground whitespace-pre-wrap mt-1">{detalhe.contextoSituacao}</p>
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Eixos e anotações</p>
+              <ul className="mt-2 space-y-2">
+                {detalhe.itensEixo.map((item) => (
+                  <li key={`${item.eixoCatalogoId}-${item.codigoEixo}`} className="rounded-lg border border-border bg-muted/40 p-3">
+                    <p className="font-semibold text-foreground">{item.rotuloEixo}</p>
+                    {item.anotacao?.trim() ? (
+                      <p className="text-muted-foreground whitespace-pre-wrap mt-1">{item.anotacao}</p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground italic mt-1">Sem anotação.</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Texto simulado (rascunho)</p>
+                <div className="flex flex-wrap gap-2">
+                  {detalhe.textoSimulado?.trim() && (
+                    <Button type="button" size="sm" variant="outline" onClick={copiarTexto}>
+                      <Copy size={14} />
+                      Copiar
+                    </Button>
+                  )}
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    loading={gerarMutation.isPending}
+                    onClick={() => gerarMutation.mutate()}
+                  >
+                    {detalhe.textoSimulado?.trim() ? 'Regenerar rascunho' : 'Gerar rascunho simulado'}
+                  </Button>
+                </div>
+              </div>
+              {detalhe.textoSimulado?.trim() ? (
+                <pre className="mt-2 whitespace-pre-wrap rounded-lg border border-border bg-muted/40 p-4 text-sm text-foreground max-h-[280px] overflow-y-auto">
+                  {detalhe.textoSimulado}
+                </pre>
+              ) : (
+                <p className="mt-2 text-muted-foreground text-sm">Ainda não há texto gerado para este registro.</p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2 items-center text-xs text-muted-foreground pt-2 border-t border-border">
+              <span>Atualizado em {new Date(detalhe.updatedAt).toLocaleString('pt-BR')}</span>
+              <Badge variant="muted">#{detalhe.id}</Badge>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web-app/src/pages/estudo-caso/EstudoCasoWizardPage.tsx
+++ b/apps/web-app/src/pages/estudo-caso/EstudoCasoWizardPage.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from 'react'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { AnimatePresence, motion } from 'framer-motion'
+import {
+  ESTUDO_CASO_WIZARD_STEPS,
+  type EstudoCasoWizardStep,
+  useEstudoCasoWizardStore,
+  canNavigateEstudoCasoTo,
+  estudoCasoStepIndex,
+} from '@/stores/estudoCasoWizardStore'
+import { StepProgressBar } from '@/components/common/StepProgressBar'
+import { PageHeader } from '@/components/common/PageHeader'
+import { EstudoCasoStep1Aluno } from './steps/EstudoCasoStep1Aluno'
+import { EstudoCasoStep2Contexto } from './steps/EstudoCasoStep2Contexto'
+import { EstudoCasoStep3Eixos } from './steps/EstudoCasoStep3Eixos'
+import { EstudoCasoStep4Resultado } from './steps/EstudoCasoStep4Resultado'
+
+const STEP_LABELS = [
+  { label: 'Aluno', description: 'Quem é o foco' },
+  { label: 'Contexto', description: 'Situação observada' },
+  { label: 'Eixos', description: 'Dimensões PAEE' },
+  { label: 'Rascunho', description: 'Texto simulado' },
+]
+
+const STEP_COMPONENTS: Record<EstudoCasoWizardStep, React.ComponentType> = {
+  aluno: EstudoCasoStep1Aluno,
+  contexto: EstudoCasoStep2Contexto,
+  eixos: EstudoCasoStep3Eixos,
+  resultado: EstudoCasoStep4Resultado,
+}
+
+const slideVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 40 : -40,
+    opacity: 0,
+  }),
+  center: { x: 0, opacity: 1 },
+  exit: (direction: number) => ({
+    x: direction < 0 ? 40 : -40,
+    opacity: 0,
+  }),
+}
+
+function redirectStepForGuard(state: ReturnType<typeof useEstudoCasoWizardStore.getState>): EstudoCasoWizardStep {
+  if (!canNavigateEstudoCasoTo('contexto', state)) return 'aluno'
+  if (!canNavigateEstudoCasoTo('eixos', state)) return 'contexto'
+  if (!canNavigateEstudoCasoTo('resultado', state)) return 'eixos'
+  return 'resultado'
+}
+
+export default function EstudoCasoWizardPage() {
+  const { step: stepParam } = useParams<{ step?: string }>()
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const currentStep = useEstudoCasoWizardStore((s) => s.currentStep)
+  const setStep = useEstudoCasoWizardStore((s) => s.setStep)
+  const setAlunoId = useEstudoCasoWizardStore((s) => s.setAlunoId)
+  const reset = useEstudoCasoWizardStore((s) => s.reset)
+
+  useEffect(() => () => {
+    reset()
+  }, [reset])
+
+  useEffect(() => {
+    const raw = searchParams.get('alunoId')
+    if (!raw) return
+    const n = Number(raw)
+    if (Number.isFinite(n) && n > 0) setAlunoId(n)
+  }, [searchParams, setAlunoId])
+
+  useEffect(() => {
+    const urlStep = (stepParam as EstudoCasoWizardStep) || 'aluno'
+    const qs = searchParams.toString()
+    const suffix = qs ? `?${qs}` : ''
+
+    if (!ESTUDO_CASO_WIZARD_STEPS.includes(urlStep)) {
+      navigate(`/estudo-caso/nova/aluno${suffix}`, { replace: true })
+      return
+    }
+
+    const state = useEstudoCasoWizardStore.getState()
+    if (!canNavigateEstudoCasoTo(urlStep, state)) {
+      const fix = redirectStepForGuard(state)
+      navigate(`/estudo-caso/nova/${fix}${suffix}`, { replace: true })
+      setStep(fix)
+      return
+    }
+
+    setStep(urlStep)
+  }, [stepParam, navigate, setStep, searchParams])
+
+  const stepIndex = estudoCasoStepIndex(currentStep)
+  const direction = stepIndex
+  const StepComponent = STEP_COMPONENTS[currentStep]
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Novo estudo de caso" backTo="/dashboard" />
+
+      <StepProgressBar steps={STEP_LABELS} currentStep={stepIndex} className="mb-2" />
+
+      <div className="overflow-hidden">
+        <AnimatePresence mode="wait" custom={direction}>
+          <motion.div
+            key={currentStep}
+            custom={direction}
+            variants={slideVariants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+          >
+            <StepComponent />
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}

--- a/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep1Aluno.tsx
+++ b/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep1Aluno.tsx
@@ -1,0 +1,84 @@
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { Users } from '@phosphor-icons/react'
+import { buscarAlunos } from '@/services/alunoService'
+import { Button } from '@/components/ui/button'
+import {
+  useEstudoCasoWizardStore,
+  canNavigateEstudoCasoTo,
+  estudoCasoStepIndex,
+  ESTUDO_CASO_WIZARD_STEPS,
+} from '@/stores/estudoCasoWizardStore'
+
+export function EstudoCasoStep1Aluno() {
+  const navigate = useNavigate()
+  const alunoId = useEstudoCasoWizardStore((s) => s.alunoId)
+  const setAlunoId = useEstudoCasoWizardStore((s) => s.setAlunoId)
+  const setStep = useEstudoCasoWizardStore((s) => s.setStep)
+
+  const { data: alunos = [], isLoading } = useQuery({
+    queryKey: ['alunos'],
+    queryFn: buscarAlunos,
+  })
+
+  function avancar() {
+    if (!alunoId) return
+    setStep('contexto')
+    navigate('/estudo-caso/nova/contexto')
+  }
+
+  const podeContexto = canNavigateEstudoCasoTo('contexto', {
+    ...useEstudoCasoWizardStore.getState(),
+    alunoId,
+  })
+
+  return (
+    <div className="max-w-xl space-y-4">
+      <div className="flex items-center gap-2 text-primary">
+        <Users size={22} weight="duotone" />
+        <h2 className="text-lg font-bold text-foreground">Aluno</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Escolha o aluno para o qual este estudo de caso será elaborado (apoio ao PAEE).
+      </p>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Carregando alunos…</p>
+      ) : (
+        <div className="space-y-2 max-h-72 overflow-y-auto rounded-lg border border-border p-2">
+          {alunos.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Nenhum aluno cadastrado.</p>
+          ) : (
+            alunos.map((a) => (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => setAlunoId(a.id ?? null)}
+                className={`w-full text-left rounded-md px-3 py-2 text-sm transition-colors border ${
+                  alunoId === a.id
+                    ? 'border-primary bg-primary/10 font-semibold text-foreground'
+                    : 'border-transparent hover:bg-muted text-foreground'
+                }`}
+              >
+                {a.nomeCompleto}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+
+      <div className="flex justify-end pt-2">
+        <Button
+          type="button"
+          onClick={avancar}
+          disabled={!alunoId || !podeContexto}
+        >
+          Continuar
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Etapa {estudoCasoStepIndex('aluno') + 1} de {ESTUDO_CASO_WIZARD_STEPS.length}
+      </p>
+    </div>
+  )
+}

--- a/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep2Contexto.tsx
+++ b/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep2Contexto.tsx
@@ -1,0 +1,90 @@
+import { useNavigate } from 'react-router-dom'
+import { Article } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  useEstudoCasoWizardStore,
+  canNavigateEstudoCasoTo,
+  estudoCasoStepIndex,
+  ESTUDO_CASO_WIZARD_STEPS,
+} from '@/stores/estudoCasoWizardStore'
+
+export function EstudoCasoStep2Contexto() {
+  const navigate = useNavigate()
+  const titulo = useEstudoCasoWizardStore((s) => s.titulo)
+  const contextoSituacao = useEstudoCasoWizardStore((s) => s.contextoSituacao)
+  const alunoId = useEstudoCasoWizardStore((s) => s.alunoId)
+  const setTitulo = useEstudoCasoWizardStore((s) => s.setTitulo)
+  const setContexto = useEstudoCasoWizardStore((s) => s.setContexto)
+  const setStep = useEstudoCasoWizardStore((s) => s.setStep)
+
+  const store = useEstudoCasoWizardStore.getState()
+
+  function voltar() {
+    setStep('aluno')
+    navigate('/estudo-caso/nova/aluno')
+  }
+
+  function avancar() {
+    setStep('eixos')
+    navigate('/estudo-caso/nova/eixos')
+  }
+
+  const ok = canNavigateEstudoCasoTo('eixos', {
+    ...store,
+    titulo,
+    contextoSituacao,
+    alunoId,
+  })
+
+  return (
+    <div className="max-w-xl space-y-4">
+      <div className="flex items-center gap-2 text-primary">
+        <Article size={22} weight="duotone" />
+        <h2 className="text-lg font-bold text-foreground">Contexto</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Título e descrição da situação observada (sala, AEE, convivência etc.).
+      </p>
+
+      <div className="space-y-2">
+        <label className="text-sm font-semibold text-foreground" htmlFor="ec-titulo">
+          Título do estudo de caso
+        </label>
+        <Input
+          id="ec-titulo"
+          value={titulo}
+          onChange={(e) => setTitulo(e.target.value)}
+          placeholder="Ex.: Participação em rodas de leitura"
+          maxLength={200}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-semibold text-foreground" htmlFor="ec-ctx">
+          Situação / contexto
+        </label>
+        <textarea
+          id="ec-ctx"
+          rows={6}
+          value={contextoSituacao}
+          onChange={(e) => setContexto(e.target.value)}
+          placeholder="Descreva fatos relevantes, frequência, suportes já testados…"
+          className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground resize-y focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+        />
+      </div>
+
+      <div className="flex justify-between pt-2">
+        <Button type="button" variant="outline" onClick={voltar}>
+          Voltar
+        </Button>
+        <Button type="button" onClick={avancar} disabled={!ok}>
+          Continuar
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Etapa {estudoCasoStepIndex('contexto') + 1} de {ESTUDO_CASO_WIZARD_STEPS.length}
+      </p>
+    </div>
+  )
+}

--- a/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep3Eixos.tsx
+++ b/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep3Eixos.tsx
@@ -1,0 +1,107 @@
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { Rows } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { buscarEixosEstudoCasoCatalogo } from '@/services/estudoCasoService'
+import {
+  useEstudoCasoWizardStore,
+  estudoCasoStepIndex,
+  ESTUDO_CASO_WIZARD_STEPS,
+} from '@/stores/estudoCasoWizardStore'
+
+export function EstudoCasoStep3Eixos() {
+  const navigate = useNavigate()
+  const eixosSelecionadosIds = useEstudoCasoWizardStore((s) => s.eixosSelecionadosIds)
+  const toggleEixo = useEstudoCasoWizardStore((s) => s.toggleEixo)
+  const anotacoesPorEixo = useEstudoCasoWizardStore((s) => s.anotacoesPorEixo)
+  const setAnotacaoEixo = useEstudoCasoWizardStore((s) => s.setAnotacaoEixo)
+  const setStep = useEstudoCasoWizardStore((s) => s.setStep)
+
+  const { data: eixos = [], isLoading } = useQuery({
+    queryKey: ['estudo-caso-eixos-catalogo'],
+    queryFn: buscarEixosEstudoCasoCatalogo,
+  })
+
+  const okResultado = eixosSelecionadosIds.length > 0
+
+  function voltar() {
+    setStep('contexto')
+    navigate('/estudo-caso/nova/contexto')
+  }
+
+  function avancar() {
+    setStep('resultado')
+    navigate('/estudo-caso/nova/resultado')
+  }
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <div className="flex items-center gap-2 text-primary">
+        <Rows size={22} weight="duotone" />
+        <h2 className="text-lg font-bold text-foreground">Eixos pedagógicos</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Marque um ou mais eixos para orientar o texto simulado. Opcionalmente acrescente observações por eixo.
+      </p>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Carregando eixos…</p>
+      ) : (
+        <div className="space-y-4">
+          {eixos.map((eixo) => {
+            const sel = eixosSelecionadosIds.includes(eixo.id)
+            return (
+              <div
+                key={eixo.id}
+                className={`rounded-lg border p-3 space-y-2 transition-colors ${
+                  sel ? 'border-primary bg-primary/5' : 'border-border bg-card'
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleEixo(eixo.id)}
+                  className="flex w-full items-start gap-3 text-left"
+                >
+                  <span
+                    className={`mt-0.5 h-5 w-5 shrink-0 rounded border-2 flex items-center justify-center text-xs font-bold ${
+                      sel ? 'border-primary bg-primary text-white' : 'border-muted-foreground/40'
+                    }`}
+                  >
+                    {sel ? '✓' : ''}
+                  </span>
+                  <span className="flex-1">
+                    <span className="font-semibold text-foreground block">{eixo.rotulo}</span>
+                    {eixo.descricaoHint && (
+                      <span className="text-xs text-muted-foreground block mt-1">{eixo.descricaoHint}</span>
+                    )}
+                  </span>
+                </button>
+                {sel && (
+                  <textarea
+                    rows={2}
+                    value={anotacoesPorEixo[eixo.id] ?? ''}
+                    onChange={(ev) => setAnotacaoEixo(eixo.id, ev.target.value)}
+                    placeholder="Observação opcional neste eixo…"
+                    className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm ml-8 max-w-[calc(100%-2rem)]"
+                  />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="flex justify-between pt-2">
+        <Button type="button" variant="outline" onClick={voltar}>
+          Voltar
+        </Button>
+        <Button type="button" onClick={avancar} disabled={!okResultado}>
+          Gerar rascunho
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Etapa {estudoCasoStepIndex('eixos') + 1} de {ESTUDO_CASO_WIZARD_STEPS.length}
+      </p>
+    </div>
+  )
+}

--- a/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep4Resultado.tsx
+++ b/apps/web-app/src/pages/estudo-caso/steps/EstudoCasoStep4Resultado.tsx
@@ -1,0 +1,122 @@
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { CheckCircle } from '@phosphor-icons/react'
+import { Button } from '@/components/ui/button'
+import { LoadingScreen } from '@/components/common/LoadingScreen'
+import { useToast } from '@/hooks/useToast'
+import { formatFriendlyErrorBody, getApiErrorFeedback } from '@/lib/apiFriendlyError'
+import { cadastrarEstudoCaso, gerarTextoSimuladoEstudoCaso } from '@/services/estudoCasoService'
+import {
+  useEstudoCasoWizardStore,
+  estudoCasoStepIndex,
+  ESTUDO_CASO_WIZARD_STEPS,
+} from '@/stores/estudoCasoWizardStore'
+
+export function EstudoCasoStep4Resultado() {
+  const navigate = useNavigate()
+  const { success, error: showError } = useToast()
+  const alunoId = useEstudoCasoWizardStore((s) => s.alunoId)
+  const titulo = useEstudoCasoWizardStore((s) => s.titulo)
+  const contextoSituacao = useEstudoCasoWizardStore((s) => s.contextoSituacao)
+  const eixosSelecionadosIds = useEstudoCasoWizardStore((s) => s.eixosSelecionadosIds)
+  const anotacoesPorEixo = useEstudoCasoWizardStore((s) => s.anotacoesPorEixo)
+  const casoIdSalvo = useEstudoCasoWizardStore((s) => s.casoIdSalvo)
+  const textoSimulado = useEstudoCasoWizardStore((s) => s.textoSimulado)
+  const setStep = useEstudoCasoWizardStore((s) => s.setStep)
+  const setCasoSalvo = useEstudoCasoWizardStore((s) => s.setCasoSalvo)
+  const reset = useEstudoCasoWizardStore((s) => s.reset)
+
+  const salvarMutation = useMutation({
+    mutationFn: async () => {
+      if (!alunoId) throw new Error('Aluno não selecionado.')
+      const itensEixo = eixosSelecionadosIds.map((id) => ({
+        eixoCatalogoId: id,
+        anotacao: (anotacoesPorEixo[id] ?? '').trim() || undefined,
+      }))
+      const criado = await cadastrarEstudoCaso({
+        alunoId,
+        titulo: titulo.trim(),
+        contextoSituacao: contextoSituacao.trim(),
+        itensEixo,
+      })
+      const comTexto = await gerarTextoSimuladoEstudoCaso(criado.id)
+      return comTexto
+    },
+    onSuccess: (detalhe) => {
+      setCasoSalvo(detalhe.id, detalhe.textoSimulado ?? null)
+      success('Estudo de caso salvo', 'Rascunho simulado gerado. Revise antes de usar oficialmente.')
+    },
+    onError: (err: unknown) => {
+      const fb = getApiErrorFeedback(err)
+      showError(fb.title, formatFriendlyErrorBody(fb))
+    },
+  })
+
+  function voltar() {
+    setStep('eixos')
+    navigate('/estudo-caso/nova/eixos')
+  }
+
+  function novo() {
+    reset()
+    navigate('/estudo-caso/nova/aluno', { replace: true })
+  }
+
+  const jaSalvo = casoIdSalvo != null && textoSimulado != null
+
+  return (
+    <>
+      <LoadingScreen visible={salvarMutation.isPending} message="Salvando e gerando rascunho…" />
+      <div className="max-w-3xl space-y-4">
+        <div className="flex items-center gap-2 text-primary">
+          <CheckCircle size={22} weight="duotone" />
+          <h2 className="text-lg font-bold text-foreground">Resultado</h2>
+        </div>
+
+        {!jaSalvo && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Confirme para registrar o estudo de caso e gerar um <strong>texto simulado</strong> (rascunho
+              automático para apoio ao PAEE — exige revisão humana).
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" onClick={voltar}>
+                Voltar
+              </Button>
+              <Button
+                type="button"
+                onClick={() => salvarMutation.mutate()}
+                loading={salvarMutation.isPending}
+              >
+                Salvar e gerar texto simulado
+              </Button>
+            </div>
+          </>
+        )}
+
+        {jaSalvo && (
+          <>
+            <p className="text-sm font-medium text-foreground">
+              Estudo #{casoIdSalvo} — texto abaixo pode ser copiado e editado externamente.
+            </p>
+            <pre className="whitespace-pre-wrap rounded-lg border border-border bg-muted/40 p-4 text-sm text-foreground max-h-[420px] overflow-y-auto">
+              {textoSimulado}
+            </pre>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" onClick={novo}>
+                Novo estudo de caso
+              </Button>
+              <Button type="button" variant="outline" onClick={() => navigate(`/alunos/${alunoId}`)}>
+                Ver perfil do aluno
+              </Button>
+            </div>
+          </>
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          Etapa {estudoCasoStepIndex('resultado') + 1} de {ESTUDO_CASO_WIZARD_STEPS.length}
+        </p>
+      </div>
+    </>
+  )
+}

--- a/apps/web-app/src/routes/index.tsx
+++ b/apps/web-app/src/routes/index.tsx
@@ -21,6 +21,7 @@ const PlanejamentoDetailPage = lazy(() => import('@/pages/planejamento/Planejame
 const AvaliacoesPage = lazy(() => import('@/pages/avaliacao/AvaliacoesPage'))
 const AvaliacaoWizardPage = lazy(() => import('@/pages/avaliacao/AvaliacaoWizardPage'))
 const AvaliacaoDesempenhoPage = lazy(() => import('@/pages/avaliacao/AvaliacaoDesempenhoPage'))
+const EstudoCasoWizardPage = lazy(() => import('@/pages/estudo-caso/EstudoCasoWizardPage'))
 const PerfilPage = lazy(() => import('@/pages/professor/PerfilPage'))
 
 function PageLoader() {
@@ -124,6 +125,14 @@ export function AppRouter() {
               element={
                 <Suspense fallback={<PageLoader />}>
                   <AvaliacaoDesempenhoPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/estudo-caso/nova/:step?"
+              element={
+                <Suspense fallback={<PageLoader />}>
+                  <EstudoCasoWizardPage />
                 </Suspense>
               }
             />

--- a/apps/web-app/src/services/estudoCasoService.ts
+++ b/apps/web-app/src/services/estudoCasoService.ts
@@ -1,0 +1,55 @@
+import { api } from '@/api/http'
+import type {
+  EstudoCasoCadastroRequest,
+  EstudoCasoDetalhe,
+  EstudoCasoEixoCatalogo,
+  EstudoCasoListaItem,
+} from '@/types/estudoCaso'
+
+interface ServiceResponse<T> {
+  sucesso: boolean
+  mensagens: string[]
+  objeto?: T | null
+  listaObjetos?: T[] | null
+}
+
+function unwrapLista<T>(data: ServiceResponse<T>): T[] {
+  if (!data.sucesso) throw new Error(data.mensagens?.join(', ') || 'Falha na API')
+  return Array.isArray(data.listaObjetos) ? data.listaObjetos : []
+}
+
+function unwrapObjeto<T>(data: ServiceResponse<T>): T {
+  if (!data.sucesso) throw new Error(data.mensagens?.join(', ') || 'Falha na API')
+  if (data.objeto === undefined || data.objeto === null) throw new Error('Resposta sem objeto')
+  return data.objeto
+}
+
+export const buscarEixosEstudoCasoCatalogo = async (): Promise<EstudoCasoEixoCatalogo[]> => {
+  const { data } = await api.get<ServiceResponse<EstudoCasoEixoCatalogo>>('/EstudoDeCaso/eixos-catalogo')
+  return unwrapLista(data)
+}
+
+export const listarEstudosCasoPorAluno = async (alunoId: number): Promise<EstudoCasoListaItem[]> => {
+  const { data } = await api.get<ServiceResponse<EstudoCasoListaItem>>(
+    `/EstudoDeCaso/por-aluno/${alunoId}`
+  )
+  return unwrapLista(data)
+}
+
+export const buscarEstudoCasoPorId = async (id: number): Promise<EstudoCasoDetalhe> => {
+  const { data } = await api.get<ServiceResponse<EstudoCasoDetalhe>>(`/EstudoDeCaso/${id}`)
+  return unwrapObjeto(data)
+}
+
+export const cadastrarEstudoCaso = async (payload: EstudoCasoCadastroRequest): Promise<EstudoCasoDetalhe> => {
+  const { data } = await api.post<ServiceResponse<EstudoCasoDetalhe>>('/EstudoDeCaso/cadastro', payload)
+  return unwrapObjeto(data)
+}
+
+export const gerarTextoSimuladoEstudoCaso = async (id: number): Promise<EstudoCasoDetalhe> => {
+  const { data } = await api.post<ServiceResponse<EstudoCasoDetalhe>>(
+    `/EstudoDeCaso/${id}/gerar-texto-simulado`,
+    {}
+  )
+  return unwrapObjeto(data)
+}

--- a/apps/web-app/src/stores/estudoCasoWizardStore.ts
+++ b/apps/web-app/src/stores/estudoCasoWizardStore.ts
@@ -1,0 +1,91 @@
+import { create } from 'zustand'
+
+export type EstudoCasoWizardStep = 'aluno' | 'contexto' | 'eixos' | 'resultado'
+
+export const ESTUDO_CASO_WIZARD_STEPS: EstudoCasoWizardStep[] = [
+  'aluno',
+  'contexto',
+  'eixos',
+  'resultado',
+]
+
+interface EstudoCasoWizardState {
+  currentStep: EstudoCasoWizardStep
+  alunoId: number | null
+  titulo: string
+  contextoSituacao: string
+  /** ids dos eixos selecionados */
+  eixosSelecionadosIds: number[]
+  /** anotações opcionais por id de eixo */
+  anotacoesPorEixo: Record<number, string>
+  casoIdSalvo: number | null
+  textoSimulado: string | null
+  setStep: (s: EstudoCasoWizardStep) => void
+  setAlunoId: (id: number | null) => void
+  setTitulo: (t: string) => void
+  setContexto: (c: string) => void
+  toggleEixo: (eixoId: number) => void
+  setAnotacaoEixo: (eixoId: number, texto: string) => void
+  setCasoSalvo: (id: number, texto: string | null) => void
+  reset: () => void
+}
+
+const initial = {
+  currentStep: 'aluno' as EstudoCasoWizardStep,
+  alunoId: null as number | null,
+  titulo: '',
+  contextoSituacao: '',
+  eixosSelecionadosIds: [] as number[],
+  anotacoesPorEixo: {} as Record<number, string>,
+  casoIdSalvo: null as number | null,
+  textoSimulado: null as string | null,
+}
+
+export const useEstudoCasoWizardStore = create<EstudoCasoWizardState>((set, get) => ({
+  ...initial,
+  setStep: (s) => set({ currentStep: s }),
+  setAlunoId: (id) => set({ alunoId: id }),
+  setTitulo: (t) => set({ titulo: t }),
+  setContexto: (c) => set({ contextoSituacao: c }),
+  toggleEixo: (eixoId) => {
+    const cur = get().eixosSelecionadosIds
+    if (cur.includes(eixoId)) {
+      set({
+        eixosSelecionadosIds: cur.filter((x) => x !== eixoId),
+      })
+    } else {
+      set({ eixosSelecionadosIds: [...cur, eixoId] })
+    }
+  },
+  setAnotacaoEixo: (eixoId, texto) =>
+    set((state) => ({
+      anotacoesPorEixo: { ...state.anotacoesPorEixo, [eixoId]: texto },
+    })),
+  setCasoSalvo: (id, texto) => set({ casoIdSalvo: id, textoSimulado: texto }),
+  reset: () => set({ ...initial }),
+}))
+
+export function estudoCasoStepIndex(step: EstudoCasoWizardStep): number {
+  return ESTUDO_CASO_WIZARD_STEPS.indexOf(step)
+}
+
+export function canNavigateEstudoCasoTo(step: EstudoCasoWizardStep, state: EstudoCasoWizardState): boolean {
+  const idx = estudoCasoStepIndex(step)
+  if (idx < 0) return false
+  if (step === 'aluno') return true
+  if (step === 'contexto') return state.alunoId != null && state.alunoId > 0
+  if (step === 'eixos') {
+    return (
+      state.alunoId != null &&
+      state.titulo.trim().length > 0 &&
+      state.contextoSituacao.trim().length > 0
+    )
+  }
+  if (step === 'resultado') {
+    return (
+      canNavigateEstudoCasoTo('eixos', state) &&
+      state.eixosSelecionadosIds.length > 0
+    )
+  }
+  return false
+}

--- a/apps/web-app/src/types/avaliacao-diagnostica.ts
+++ b/apps/web-app/src/types/avaliacao-diagnostica.ts
@@ -4,6 +4,23 @@ export type NivelRealizacao =
   | 'NaoRealizou'
   | 'NaoAvaliado'
 
+/** Perfil agregado (substitui percentual numérico legado em diagnósticos persistidos). */
+export type NivelPerfilAutonomia =
+  | 'NaoAvaliado'
+  | 'PredominioDependencia'
+  | 'AutonomiaMediada'
+  | 'PredominioAutonomia'
+
+export interface AlunoPerfilAutonomiaResumo {
+  alunoId: number
+  nomeCompleto: string
+  nivelPerfilAutonomia: NivelPerfilAutonomia | string
+  rotuloExibicao: string
+  sugestaoPaee: string
+  /** Proporção de atividades em "Autonomia" entre as já avaliadas; ausente se não houver base. */
+  percentualAutonomiaCalculado?: number | null
+}
+
 export interface AvaliacaoDiagnosticaResumo {
   id: number
   titulo: string
@@ -74,7 +91,8 @@ export interface AvaliacaoDiagnosticaDetalhada {
     status?: 'Pendente' | 'EmAndamento' | 'Concluido'
   }>
   blocosComAtividades?: BlocoComAtividadesDetalhe[]
-  /** API retorna registrosDesempenho para cálculo de percentual */
+  /** Visão agregada por aluno (níveis discretos + sugestão PAEE); calculado na API a partir dos lançamentos. */
+  perfisAutonomiaPorAluno?: AlunoPerfilAutonomiaResumo[]
   registrosDesempenho?: Array<{
     id?: number
     alunoId: number
@@ -168,7 +186,7 @@ export interface DiagnosticoFinal {
   alunoId: number
   aluno: { id: number; nomeCompleto: string }
   resumo: string
-  percentualAutonomia: number
+  nivelPerfilAutonomia: NivelPerfilAutonomia | string
   recomendacoes: string
   habilidadesFortes?: string
   habilidadesAReenforcar?: string
@@ -180,7 +198,8 @@ export interface DiagnosticoFinal {
 export interface DiagnosticoResumo {
   id: number
   alunoNome: string
-  percentualAutonomia: number
+  nivelPerfilAutonomia: NivelPerfilAutonomia | string
+  rotuloExibicao?: string
   resumoCurto: string
   geradoEm: string
 }

--- a/apps/web-app/src/types/estudoCaso.ts
+++ b/apps/web-app/src/types/estudoCaso.ts
@@ -1,0 +1,43 @@
+export interface EstudoCasoEixoCatalogo {
+  id: number
+  codigo: string
+  rotulo: string
+  descricaoHint?: string | null
+  ordemExibicao: number
+}
+
+export interface EstudoCasoItemEixoPayload {
+  eixoCatalogoId: number
+  anotacao?: string | null
+}
+
+export interface EstudoCasoCadastroRequest {
+  alunoId: number
+  titulo: string
+  contextoSituacao: string
+  itensEixo: EstudoCasoItemEixoPayload[]
+}
+
+export interface EstudoCasoItemDetalhe extends EstudoCasoItemEixoPayload {
+  codigoEixo: string
+  rotuloEixo: string
+}
+
+export interface EstudoCasoDetalhe {
+  id: number
+  alunoId: number
+  alunoNomeCompleto: string
+  titulo: string
+  contextoSituacao: string
+  textoSimulado?: string | null
+  createdAt: string
+  updatedAt: string
+  itensEixo: EstudoCasoItemDetalhe[]
+}
+
+export interface EstudoCasoListaItem {
+  id: number
+  titulo: string
+  updatedAt: string
+  possuiTextoSimulado: boolean
+}


### PR DESCRIPTION
**Título:**  
`feat(PAEE): estudos de caso no perfil do aluno e deep link no wizard`

**Descrição:**

**O quê**
- Seção **Estudos de caso** na página do aluno: lista via API `por-aluno`, badges de rascunho, atalho **Novo estudo** e **Ver detalhes** em diálogo com contexto, eixos, texto simulado, copiar e gerar/regenerar rascunho.
- Wizard de estudo de caso lê `?alunoId=` e mantém a query string nos redirects do guard para não perder o parâmetro.

**Por quê**
- Dar visibilidade dos registros já criados por aluno e fluxo rápido para novo caso a partir do perfil.

**Como testar**
- Abrir `/alunos/:id` com aluno que tenha (e outro sem) estudos; conferir lista, diálogo e botões copiar/regenerar.
- Clicar **Novo estudo** e validar aluno pré-selecionado na etapa 1.
- Navegar entre etapas com URL corrigida pelo guard e conferir que `?alunoId=` permanece quando aplicável.