### PR TITLE
feat(api): PAEE fase 4 — encontros, objetivos e metadados de assinatura

### DIFF
--- a/apps/api/Controllers/PlanejamentoController.cs
+++ b/apps/api/Controllers/PlanejamentoController.cs
@@ -254,6 +254,32 @@ namespace api.Controllers
             return BadRequest(ModelState);
         }
 
+        [HttpPut("{id}/encontros")]
+        public async Task<IActionResult> SubstituirEncontros(int id,
+            [FromBody] PlanejamentoEncontrosSubstituicaoDTO dto)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var usuario = await _usuario.GetUserAsync(User);
+            var resposta = await _planejamentoService.SubstituirEncontros(id, dto, usuario);
+            if (resposta.Sucesso)
+                return Ok(resposta);
+
+            return BadRequest(resposta);
+        }
+
+        [HttpGet("{id}/sugestao-datas")]
+        public async Task<IActionResult> SugestaoDatasEncontros(int id)
+        {
+            var usuario = await _usuario.GetUserAsync(User);
+            var resposta = await _planejamentoService.SugerirDatasEncontro(id, usuario);
+            if (resposta.Sucesso)
+                return Ok(resposta);
+
+            return BadRequest(resposta);
+        }
+
         [HttpDelete("{id}")]
         public async Task<IActionResult> Excluir(int id)
         {

--- a/apps/api/DTOs/Planejamento/PaeeEncontroBuscarDTO.cs
+++ b/apps/api/DTOs/Planejamento/PaeeEncontroBuscarDTO.cs
@@ -1,0 +1,16 @@
+namespace api.DTOs.Planejamento;
+
+public class PaeeEncontroBuscarDTO
+{
+    public int Id { get; set; }
+
+    public DateOnly DataEnc { get; set; }
+
+    public string? TextoPlanejado { get; set; }
+
+    public string? TextoRealizado { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    public int? EstrategiaId { get; set; }
+}

--- a/apps/api/DTOs/Planejamento/PaeeEncontroEntradaDTO.cs
+++ b/apps/api/DTOs/Planejamento/PaeeEncontroEntradaDTO.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.DTOs.Planejamento;
+
+public class PaeeEncontroEntradaDTO
+{
+    [Required]
+    public DateOnly DataEnc { get; set; }
+
+    public string? TextoPlanejado { get; set; }
+
+    public string? TextoRealizado { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    public int? EstrategiaId { get; set; }
+}

--- a/apps/api/DTOs/Planejamento/PaeeSugestaoDatasDTO.cs
+++ b/apps/api/DTOs/Planejamento/PaeeSugestaoDatasDTO.cs
@@ -1,0 +1,9 @@
+namespace api.DTOs.Planejamento;
+
+public class PaeeSugestaoDatasDTO
+{
+    /// <summary>
+    /// Datas sugeridas (primeiro aluno vinculado, ordenação por nome) dentro do período do PAEE.
+    /// </summary>
+    public List<DateOnly> Datas { get; set; } = [];
+}

--- a/apps/api/DTOs/Planejamento/PlanejamentoAtualizarDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoAtualizarDTO.cs
@@ -14,5 +14,17 @@ namespace api.DTOs.Planejamento
         public DateOnly? DataFim { get; set; }
 
         public string? DescicaoPlanejamento { get; set; }
+
+        public string? ObjetivoCurtoPrazo { get; set; }
+
+        public string? ObjetivoMedioPrazo { get; set; }
+
+        public string? ObjetivoLongoPrazo { get; set; }
+
+        public bool? DocumentoDeclaradoAssinado { get; set; }
+
+        public string? AssinaturaNomeResponsavel { get; set; }
+
+        public string? AssinaturaCargo { get; set; }
     }
 }

--- a/apps/api/DTOs/Planejamento/PlanejamentoBuscarDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoBuscarDTO.cs
@@ -21,5 +21,19 @@ namespace api.DTOs.Planejamento
         public List<AlunoResumoDTO> Alunos { get; set; } = new();
         public List<EstrategiaBuscarDTO> Estrategias { get; set; } = new();
         public List<AvaliacaoBuscarDTO> Avaliacao { get; set; } = new();
+
+        public string? ObjetivoCurtoPrazo { get; set; }
+
+        public string? ObjetivoMedioPrazo { get; set; }
+
+        public string? ObjetivoLongoPrazo { get; set; }
+
+        public bool DocumentoDeclaradoAssinado { get; set; }
+
+        public string? AssinaturaNomeResponsavel { get; set; }
+
+        public string? AssinaturaCargo { get; set; }
+
+        public List<PaeeEncontroBuscarDTO> Encontros { get; set; } = [];
     }
 }

--- a/apps/api/DTOs/Planejamento/PlanejamentoEncontrosSubstituicaoDTO.cs
+++ b/apps/api/DTOs/Planejamento/PlanejamentoEncontrosSubstituicaoDTO.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.DTOs.Planejamento;
+
+public class PlanejamentoEncontrosSubstituicaoDTO
+{
+    [Required]
+    public List<PaeeEncontroEntradaDTO> Encontros { get; set; } = [];
+}

--- a/apps/api/Data/AppDbContext.cs
+++ b/apps/api/Data/AppDbContext.cs
@@ -16,6 +16,7 @@ namespace Data
         public DbSet<EscolaXProfessor> EscolasXProfessores { get; set; }
         public DbSet<Habilidade> Habilidades { get; set; }
         public DbSet<Planejamento> Planejamentos { get; set; }
+        public DbSet<PlanejamentoEncontro> PlanejamentoEncontros { get; set; }
         public DbSet<AlunosXPlanejamento> AlunosXPlanejamentos { get; set; }
         public DbSet<HabilidadesXPlanejamento> HabilidadesXPlanejamentos { get; set; }
 
@@ -146,6 +147,30 @@ namespace Data
                 .HasOne(pa => pa.Aluno)
                 .WithMany(a => a.AlunosXPlanejamentos)
                 .HasForeignKey(pa => pa.AlunoId);
+
+            modelBuilder.Entity<PlanejamentoEncontro>()
+                .HasOne(e => e.Planejamento)
+                .WithMany(p => p.Encontros)
+                .HasForeignKey(e => e.PlanejamentoId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<PlanejamentoEncontro>()
+                .HasOne(e => e.Habilidade)
+                .WithMany()
+                .HasForeignKey(e => e.HabilidadeId)
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired(false);
+
+            modelBuilder.Entity<PlanejamentoEncontro>()
+                .HasOne(e => e.Estrategia)
+                .WithMany()
+                .HasForeignKey(e => e.EstrategiaId)
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired(false);
+
+            modelBuilder.Entity<PlanejamentoEncontro>()
+                .HasIndex(e => new { e.PlanejamentoId, e.DataEnc })
+                .HasDatabaseName("ix_planejamento_encontros_planejamentoid_dataenc");
 
             // Bloco ↔ Atividade (1:N)
             modelBuilder.Entity<Bloco>()

--- a/apps/api/Migrations/20260525221435_PaeeFase4EncontrosObjetivosAssinatura.Designer.cs
+++ b/apps/api/Migrations/20260525221435_PaeeFase4EncontrosObjetivosAssinatura.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525221435_PaeeFase4EncontrosObjetivosAssinatura")]
+    partial class PaeeFase4EncontrosObjetivosAssinatura
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/Migrations/20260525221435_PaeeFase4EncontrosObjetivosAssinatura.cs
+++ b/apps/api/Migrations/20260525221435_PaeeFase4EncontrosObjetivosAssinatura.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PaeeFase4EncontrosObjetivosAssinatura : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "assinaturacargo",
+                table: "planejamentos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "assinaturanomeresponsavel",
+                table: "planejamentos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "documentodeclaradoassinado",
+                table: "planejamentos",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "objetivocurtoprazo",
+                table: "planejamentos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "objetivolongoprazo",
+                table: "planejamentos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "objetivomedioprazo",
+                table: "planejamentos",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "planejamento_encontros",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    planejamentoid = table.Column<int>(type: "integer", nullable: false),
+                    dataenc = table.Column<DateOnly>(type: "date", nullable: false),
+                    textoplanejado = table.Column<string>(type: "text", nullable: true),
+                    textorealizado = table.Column<string>(type: "text", nullable: true),
+                    habilidadeid = table.Column<int>(type: "integer", nullable: true),
+                    estrategiaid = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_planejamento_encontros", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_planejamento_encontros_estrategias_estrategiaid",
+                        column: x => x.estrategiaid,
+                        principalTable: "estrategias",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_planejamento_encontros_habilidades_habilidadeid",
+                        column: x => x.habilidadeid,
+                        principalTable: "habilidades",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_planejamento_encontros_planejamentos_planejamentoid",
+                        column: x => x.planejamentoid,
+                        principalTable: "planejamentos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_planejamento_encontros_estrategiaid",
+                table: "planejamento_encontros",
+                column: "estrategiaid");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_planejamento_encontros_habilidadeid",
+                table: "planejamento_encontros",
+                column: "habilidadeid");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_planejamento_encontros_planejamentoid_dataenc",
+                table: "planejamento_encontros",
+                columns: new[] { "planejamentoid", "dataenc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "planejamento_encontros");
+
+            migrationBuilder.DropColumn(
+                name: "assinaturacargo",
+                table: "planejamentos");
+
+            migrationBuilder.DropColumn(
+                name: "assinaturanomeresponsavel",
+                table: "planejamentos");
+
+            migrationBuilder.DropColumn(
+                name: "documentodeclaradoassinado",
+                table: "planejamentos");
+
+            migrationBuilder.DropColumn(
+                name: "objetivocurtoprazo",
+                table: "planejamentos");
+
+            migrationBuilder.DropColumn(
+                name: "objetivolongoprazo",
+                table: "planejamentos");
+
+            migrationBuilder.DropColumn(
+                name: "objetivomedioprazo",
+                table: "planejamentos");
+        }
+    }
+}

--- a/apps/api/Models/Planejamento.cs
+++ b/apps/api/Models/Planejamento.cs
@@ -21,6 +21,17 @@ public class Planejamento
 
     public string DescicaoPlanejamento { get; set; }
 
+    public string? ObjetivoCurtoPrazo { get; set; }
+
+    public string? ObjetivoMedioPrazo { get; set; }
+
+    public string? ObjetivoLongoPrazo { get; set; }
+
+    public bool DocumentoDeclaradoAssinado { get; set; }
+
+    public string? AssinaturaNomeResponsavel { get; set; }
+
+    public string? AssinaturaCargo { get; set; }
 
     public ICollection<HabilidadesXPlanejamento> HabilidadesXPlanejamentos { get; set; }
 
@@ -28,5 +39,7 @@ public class Planejamento
 
     public ICollection<AvaliacaoXPlanejamento> AvaliacaoXPlanejamentos { get; set; }
     public ICollection<AlunosXPlanejamento> AlunosXPlanejamentos { get; set; }
+
+    public ICollection<PlanejamentoEncontro> Encontros { get; set; } = [];
 
 }

--- a/apps/api/Models/PlanejamentoEncontro.cs
+++ b/apps/api/Models/PlanejamentoEncontro.cs
@@ -1,0 +1,32 @@
+namespace api.Models;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+[Table("planejamento_encontros")]
+public class PlanejamentoEncontro
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int PlanejamentoId { get; set; }
+
+    [ForeignKey("PlanejamentoId")]
+    public Planejamento Planejamento { get; set; } = null!;
+
+    public DateOnly DataEnc { get; set; }
+
+    public string? TextoPlanejado { get; set; }
+
+    public string? TextoRealizado { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    [ForeignKey("HabilidadeId")]
+    public Habilidade? Habilidade { get; set; }
+
+    public int? EstrategiaId { get; set; }
+
+    [ForeignKey("EstrategiaId")]
+    public Estrategias? Estrategia { get; set; }
+}

--- a/apps/api/Services/PaeeDatasSugeridasGerador.cs
+++ b/apps/api/Services/PaeeDatasSugeridasGerador.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+
+namespace api.Services;
+
+/// <summary>
+/// Gera datas de encontro sugeridas no intervalo conforme dias da semana e limite opcional pela frequência.
+/// </summary>
+public static class PaeeDatasSugeridasGerador
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+
+    private static readonly Dictionary<string, DayOfWeek> DiaCanonicoParaDow =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Segunda"] = DayOfWeek.Monday,
+            ["Terça"] = DayOfWeek.Tuesday,
+            ["Quarta"] = DayOfWeek.Wednesday,
+            ["Quinta"] = DayOfWeek.Thursday,
+            ["Sexta"] = DayOfWeek.Friday,
+            ["Sábado"] = DayOfWeek.Saturday,
+            ["Domingo"] = DayOfWeek.Sunday,
+        };
+
+    private static bool TryCanonizarDiaSemana(string entrada, out string canonico)
+    {
+        canonico = "";
+        if (string.IsNullOrWhiteSpace(entrada))
+            return false;
+
+        var k = entrada.Trim().ToLowerInvariant()
+            .Normalize(System.Text.NormalizationForm.FormD);
+        var chars = k.Where(static c =>
+            System.Globalization.CharUnicodeInfo.GetUnicodeCategory(c)
+            != System.Globalization.UnicodeCategory.NonSpacingMark).ToArray();
+        k = new string(chars);
+
+        canonico = k switch
+        {
+            "segunda" or "segunda-feira" => "Segunda",
+            "terca" or "terça" or "terca-feira" or "terça-feira" => "Terça",
+            "quarta" or "quarta-feira" => "Quarta",
+            "quinta" or "quinta-feira" => "Quinta",
+            "sexta" or "sexta-feira" => "Sexta",
+            "sabado" or "sábado" => "Sábado",
+            "domingo" => "Domingo",
+            _ => "",
+        };
+
+        return !string.IsNullOrEmpty(canonico);
+    }
+
+    public static List<string> DeserializarDiasDaSemana(string? diasSemanaAtendimentoJson)
+    {
+        if (string.IsNullOrWhiteSpace(diasSemanaAtendimentoJson))
+            return [];
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(diasSemanaAtendimentoJson, JsonOpts) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Todas as datas em [dataInicio, dataFim] cujo dia coincide com os informados em ordenação ascendente,
+    /// limitadas a um teto segurança (<paramref name="tetoDatas"/>).
+    /// </summary>
+    public static IReadOnlyList<DateOnly> Sugerir(
+        DateOnly dataInicio,
+        DateOnly dataFim,
+        IReadOnlyCollection<string>? diasBrutosOuCanonicoPtBr,
+        int? frequenciaSemanal,
+        int tetoDatas = 400)
+    {
+        if (diasBrutosOuCanonicoPtBr == null || diasBrutosOuCanonicoPtBr.Count == 0)
+            return [];
+
+        var lista = diasBrutosOuCanonicoPtBr
+            .Select(static d =>
+            {
+                TryCanonizarDiaSemana(d, out var c);
+                return c;
+            })
+            .Where(static c => DiaCanonicoParaDow.ContainsKey(c))
+            .Distinct()
+            .ToList();
+
+        if (lista.Count == 0)
+            return [];
+        var dows = lista.Select(static d => DiaCanonicoParaDow[d]).ToHashSet();
+
+        double? tentativaMax = frequenciaSemanal.HasValue && frequenciaSemanal.Value >= 1
+            ? EstimateMaxDates(dataInicio, dataFim, frequenciaSemanal.Value)
+            : null;
+
+        var resultado = new List<DateOnly>();
+        for (var d = dataInicio; d <= dataFim; d = d.AddDays(1))
+        {
+            if (!dows.Contains(d.DayOfWeek))
+                continue;
+            resultado.Add(d);
+            if (resultado.Count >= tetoDatas)
+                break;
+            if (tentativaMax is double max && resultado.Count >= max)
+                break;
+        }
+
+        return resultado;
+    }
+
+    /// <summary>
+    /// Aproxima número de dias de encontro: semanas inteiras cobertas * frequênciaSemanal + folga para semana parcial.
+    /// </summary>
+    private static double EstimateMaxDates(DateOnly dataInicio, DateOnly dataFim, int frequenciaSemanal)
+    {
+        var diasCalendar = dataFim.DayNumber - dataInicio.DayNumber + 1;
+        var semanasAproximadas = Math.Max(1, diasCalendar / 7.0);
+        return Math.Ceiling(semanasAproximadas * frequenciaSemanal) + frequenciaSemanal;
+    }
+}

--- a/apps/api/Services/PlanejamentoService.cs
+++ b/apps/api/Services/PlanejamentoService.cs
@@ -22,9 +22,65 @@ namespace api.Services
             _usuario = usuario;
         }
 
+        private static bool PeriodosSobrepostos(DateOnly i1, DateOnly f1, DateOnly i2, DateOnly f2) =>
+            i1 <= f2 && i2 <= f1;
+
+        /// <returns>Mensagem de erro ou null quando não há conflito.</returns>
+        private async Task<string?> ObterMensagemOverlapAoDefinirPeriodoParaPlano(
+            int professorId,
+            int planejamentoId,
+            DateOnly iniProspectivo,
+            DateOnly fimProspectivo)
+        {
+            var apelidoConflituoso = await (
+                from minha in _contexto.AlunosXPlanejamentos.Where(x => x.PlanejamentoId == planejamentoId)
+                join outra in _contexto.AlunosXPlanejamentos on minha.AlunoId equals outra.AlunoId
+                where outra.PlanejamentoId != planejamentoId
+                join p in _contexto.Planejamentos on outra.PlanejamentoId equals p.ID
+                where p.IdProfessor == professorId
+                      && PeriodosSobrepostos(iniProspectivo, fimProspectivo, p.DataInicio, p.DataFim)
+                select p.Apelido
+            ).FirstOrDefaultAsync();
+
+            return apelidoConflituoso != null
+                ? $"Há aluno(ns) já vinculado(s) a outro PAEE com período intersectando (PAEE «{apelidoConflituoso}»)."
+                : null;
+        }
+
+        private async Task<string?> ObterMensagemOverlapAoVincularAlunoAsync(int professorId, int planejamentoId,
+            int alunoId)
+        {
+            var atual = await _contexto.Planejamentos.AsNoTracking()
+                .Where(p => p.ID == planejamentoId && p.IdProfessor == professorId)
+                .Select(p => new { p.DataInicio, p.DataFim })
+                .FirstOrDefaultAsync();
+            if (atual == null)
+                return null;
+
+            var apelidoConflituoso = await _contexto.AlunosXPlanejamentos
+                .Where(ax => ax.AlunoId == alunoId && ax.PlanejamentoId != planejamentoId)
+                .Join(_contexto.Planejamentos.Where(p => p.IdProfessor == professorId),
+                    ax => ax.PlanejamentoId,
+                    p => p.ID,
+                    (_, p) => p)
+                .Where(p => PeriodosSobrepostos(atual.DataInicio, atual.DataFim, p.DataInicio, p.DataFim))
+                .Select(p => p.Apelido)
+                .FirstOrDefaultAsync();
+
+            return apelidoConflituoso != null
+                ? $"Este aluno já participa do PAEE «{apelidoConflituoso}» em período que intersecta este PAEE."
+                : null;
+        }
+
         public async Task<ServiceResponse<PlanejamentoCadastroDTO>> Cadastro(PlanejamentoCadastroDTO planejamentoDTO, Usuario usuario)
         {
             var resposta = new ServiceResponse<PlanejamentoCadastroDTO>();
+            if (planejamentoDTO.DataInicio > planejamentoDTO.DataFim)
+            {
+                resposta.SetFalha("Data de início não pode ser posterior à data de fim.");
+                return resposta;
+            }
+
             using (var transacao = await _contexto.Database.BeginTransactionAsync())
             {
                 try
@@ -69,6 +125,22 @@ namespace api.Services
                     return resposta;
                 }
 
+                var novoInicio = planejamentoDTO.DataInicio ?? planejamento.DataInicio;
+                var novoFim = planejamentoDTO.DataFim ?? planejamento.DataFim;
+                if (novoInicio > novoFim)
+                {
+                    resposta.SetFalha("Data de início não pode ser posterior à data de fim.");
+                    return resposta;
+                }
+
+                var professorId = (int)usuario.ProfessorId;
+                var overlapMsg = await ObterMensagemOverlapAoDefinirPeriodoParaPlano(professorId, planejamento.ID, novoInicio, novoFim);
+                if (overlapMsg != null)
+                {
+                    resposta.SetFalha(overlapMsg);
+                    return resposta;
+                }
+
                 if (!string.IsNullOrEmpty(planejamentoDTO.Apelido))
                 {
                     planejamento.Apelido= planejamentoDTO.Apelido;
@@ -88,6 +160,19 @@ namespace api.Services
                 {
                         planejamento.DescicaoPlanejamento = planejamentoDTO.DescicaoPlanejamento;
                  }
+
+                if (planejamentoDTO.ObjetivoCurtoPrazo != null)
+                    planejamento.ObjetivoCurtoPrazo = planejamentoDTO.ObjetivoCurtoPrazo;
+                if (planejamentoDTO.ObjetivoMedioPrazo != null)
+                    planejamento.ObjetivoMedioPrazo = planejamentoDTO.ObjetivoMedioPrazo;
+                if (planejamentoDTO.ObjetivoLongoPrazo != null)
+                    planejamento.ObjetivoLongoPrazo = planejamentoDTO.ObjetivoLongoPrazo;
+                if (planejamentoDTO.DocumentoDeclaradoAssinado.HasValue)
+                    planejamento.DocumentoDeclaradoAssinado = planejamentoDTO.DocumentoDeclaradoAssinado.Value;
+                if (planejamentoDTO.AssinaturaNomeResponsavel != null)
+                    planejamento.AssinaturaNomeResponsavel = planejamentoDTO.AssinaturaNomeResponsavel;
+                if (planejamentoDTO.AssinaturaCargo != null)
+                    planejamento.AssinaturaCargo = planejamentoDTO.AssinaturaCargo;
 
                     await _contexto.SaveChangesAsync();
             }
@@ -115,6 +200,23 @@ namespace api.Services
                         DataInicio = p.DataInicio,
                         DataFim = p.DataFim,
                         DescicaoPlanejamento = p.DescicaoPlanejamento,
+                        ObjetivoCurtoPrazo = p.ObjetivoCurtoPrazo,
+                        ObjetivoMedioPrazo = p.ObjetivoMedioPrazo,
+                        ObjetivoLongoPrazo = p.ObjetivoLongoPrazo,
+                        DocumentoDeclaradoAssinado = p.DocumentoDeclaradoAssinado,
+                        AssinaturaNomeResponsavel = p.AssinaturaNomeResponsavel,
+                        AssinaturaCargo = p.AssinaturaCargo,
+                        Encontros = p.Encontros
+                            .OrderBy(e => e.DataEnc).ThenBy(e => e.Id)
+                            .Select(e => new PaeeEncontroBuscarDTO
+                            {
+                                Id = e.Id,
+                                DataEnc = e.DataEnc,
+                                TextoPlanejado = e.TextoPlanejado,
+                                TextoRealizado = e.TextoRealizado,
+                                HabilidadeId = e.HabilidadeId,
+                                EstrategiaId = e.EstrategiaId,
+                            }).ToList(),
                         Habilidades = p.HabilidadesXPlanejamentos
                             .Select(hp => new HabilidadeBuscarDTO
                             {
@@ -175,6 +277,23 @@ namespace api.Services
                         DataInicio = p.DataInicio,
                         DataFim = p.DataFim,
                         DescicaoPlanejamento = p.DescicaoPlanejamento,
+                        ObjetivoCurtoPrazo = p.ObjetivoCurtoPrazo,
+                        ObjetivoMedioPrazo = p.ObjetivoMedioPrazo,
+                        ObjetivoLongoPrazo = p.ObjetivoLongoPrazo,
+                        DocumentoDeclaradoAssinado = p.DocumentoDeclaradoAssinado,
+                        AssinaturaNomeResponsavel = p.AssinaturaNomeResponsavel,
+                        AssinaturaCargo = p.AssinaturaCargo,
+                        Encontros = p.Encontros
+                            .OrderBy(e => e.DataEnc).ThenBy(e => e.Id)
+                            .Select(e => new PaeeEncontroBuscarDTO
+                            {
+                                Id = e.Id,
+                                DataEnc = e.DataEnc,
+                                TextoPlanejado = e.TextoPlanejado,
+                                TextoRealizado = e.TextoRealizado,
+                                HabilidadeId = e.HabilidadeId,
+                                EstrategiaId = e.EstrategiaId,
+                            }).ToList(),
                         Habilidades = p.HabilidadesXPlanejamentos
                             .Select(hp => new HabilidadeBuscarDTO
                             {
@@ -217,6 +336,150 @@ namespace api.Services
             catch (Exception)
             {
                 resposta.SetFalha("Erro ao buscar planejamento.");
+                return resposta;
+            }
+        }
+
+        public async Task<ServiceResponse<bool>> SubstituirEncontros(
+            int idPlanejamento,
+            PlanejamentoEncontrosSubstituicaoDTO dto,
+            Usuario usuario)
+        {
+            var resposta = new ServiceResponse<bool>();
+
+            await using var transacao = await _contexto.Database.BeginTransactionAsync();
+            try
+            {
+                var professorId = (int)usuario.ProfessorId!;
+                var planejamento = await _contexto.Planejamentos.FirstOrDefaultAsync(p =>
+                    p.ID == idPlanejamento && p.IdProfessor == professorId);
+                if (planejamento == null)
+                {
+                    await transacao.RollbackAsync();
+                    resposta.SetFalha("Planejamento não encontrado.");
+                    return resposta;
+                }
+
+                var habIdsComChave = dto.Encontros
+                    .Where(e => e.HabilidadeId.HasValue)
+                    .Select(e => e.HabilidadeId!.Value).Distinct().ToList();
+                if (habIdsComChave.Count > 0)
+                {
+                    var countH = await _contexto.Habilidades.CountAsync(h => habIdsComChave.Contains(h.Id));
+                    if (countH != habIdsComChave.Count)
+                    {
+                        await transacao.RollbackAsync();
+                        resposta.SetFalha("Uma ou mais habilidades informadas não existem.");
+                        return resposta;
+                    }
+                }
+
+                var estrIdsComChave = dto.Encontros
+                    .Where(e => e.EstrategiaId.HasValue)
+                    .Select(e => e.EstrategiaId!.Value).Distinct().ToList();
+                if (estrIdsComChave.Count > 0)
+                {
+                    var countE =
+                        await _contexto.Estrategias.CountAsync(e => estrIdsComChave.Contains(e.Id));
+                    if (countE != estrIdsComChave.Count)
+                    {
+                        await transacao.RollbackAsync();
+                        resposta.SetFalha("Uma ou mais estratégias informadas não existem.");
+                        return resposta;
+                    }
+                }
+
+                foreach (var linha in dto.Encontros)
+                {
+                    if (linha.DataEnc < planejamento.DataInicio || linha.DataEnc > planejamento.DataFim)
+                    {
+                        await transacao.RollbackAsync();
+                        resposta.SetFalha(
+                            "Cada encontro precisa estar com data dentro do período do PAEE (início até fim).");
+                        return resposta;
+                    }
+                }
+
+                var existentes =
+                    await _contexto.PlanejamentoEncontros.Where(e => e.PlanejamentoId == idPlanejamento)
+                        .ToListAsync();
+                _contexto.PlanejamentoEncontros.RemoveRange(existentes);
+
+                foreach (var linha in dto.Encontros)
+                {
+                    _contexto.PlanejamentoEncontros.Add(new PlanejamentoEncontro
+                    {
+                        PlanejamentoId = idPlanejamento,
+                        DataEnc = linha.DataEnc,
+                        TextoPlanejado = linha.TextoPlanejado,
+                        TextoRealizado = linha.TextoRealizado,
+                        HabilidadeId = linha.HabilidadeId,
+                        EstrategiaId = linha.EstrategiaId,
+                    });
+                }
+
+                await _contexto.SaveChangesAsync();
+                await transacao.CommitAsync();
+                resposta.Sucesso = true;
+                resposta.AdicionaObjeto(true);
+                resposta.AdicionaMensagem("Encontros atualizados com sucesso.");
+                return resposta;
+            }
+            catch (Exception ex)
+            {
+                await transacao.RollbackAsync();
+                resposta.SetFalha(ex.Message);
+                return resposta;
+            }
+        }
+
+        public async Task<ServiceResponse<PaeeSugestaoDatasDTO>> SugerirDatasEncontro(int idPlanejamento,
+            Usuario usuario)
+        {
+            var resposta = new ServiceResponse<PaeeSugestaoDatasDTO>();
+            try
+            {
+                var professorId = (int)usuario.ProfessorId!;
+                var planoCtx = await _contexto.Planejamentos.AsNoTracking()
+                    .Where(p => p.ID == idPlanejamento && p.IdProfessor == professorId)
+                    .Select(p => new { p.DataInicio, p.DataFim })
+                    .FirstOrDefaultAsync();
+                if (planoCtx == null)
+                {
+                    resposta.SetFalha("Planejamento não encontrado.");
+                    return resposta;
+                }
+
+                var alunoPrim = await _contexto.AlunosXPlanejamentos
+                    .Where(ax => ax.PlanejamentoId == idPlanejamento)
+                    .Join(_contexto.Alunos.Where(a => a.IdProfessor == professorId), ax => ax.AlunoId, a => a.Id,
+                        (_, a) => a)
+                    .OrderBy(a => a.NomeCompleto)
+                    .Select(a => new { a.FrequenciaSemanalAtendimento, a.DiasSemanaAtendimentoJson })
+                    .FirstOrDefaultAsync();
+
+                if (alunoPrim == null)
+                {
+                    resposta.AdicionaObjeto(new PaeeSugestaoDatasDTO());
+                    resposta.AdicionaMensagem(
+                        "Nenhum aluno vinculado ao PAEE: não há base para sugerir datas de encontros.");
+                    return resposta;
+                }
+
+                var diasBrutos =
+                    PaeeDatasSugeridasGerador.DeserializarDiasDaSemana(alunoPrim.DiasSemanaAtendimentoJson);
+
+                var lista = PaeeDatasSugeridasGerador
+                    .Sugerir(planoCtx.DataInicio, planoCtx.DataFim, diasBrutos,
+                        alunoPrim.FrequenciaSemanalAtendimento)
+                    .ToList();
+
+                resposta.AdicionaObjeto(new PaeeSugestaoDatasDTO { Datas = lista });
+                return resposta;
+            }
+            catch (Exception ex)
+            {
+                resposta.SetFalha(ex.Message);
                 return resposta;
             }
         }
@@ -304,6 +567,14 @@ namespace api.Services
             if (jaVinculado)
             {
                 resposta.SetFalha("Este aluno já está vinculado a esse planejamento.");
+                return resposta;
+            }
+
+            var overlap = await ObterMensagemOverlapAoVincularAlunoAsync((int)usuario.ProfessorId!,
+                planejamentoVincularAlunoDto.IdPlanejamento, planejamentoVincularAlunoDto.IdAluno);
+            if (overlap != null)
+            {
+                resposta.SetFalha(overlap);
                 return resposta;
             }
 
@@ -481,8 +752,16 @@ namespace api.Services
                 .Select(x => x.AlunoId)
                 .ToListAsync();
             var setJa = jaVinculados.ToHashSet();
+            var professorId = (int)usuario.ProfessorId!;
             foreach (var alunoId in distinctIds.Where(id => !setJa.Contains(id)))
             {
+                var overlap = await ObterMensagemOverlapAoVincularAlunoAsync(professorId, dto.IdPlanejamento, alunoId);
+                if (overlap != null)
+                {
+                    resposta.SetFalha(overlap);
+                    return resposta;
+                }
+
                 _contexto.AlunosXPlanejamentos.Add(new AlunosXPlanejamento
                 {
                     AlunoId = alunoId,


### PR DESCRIPTION
- Migration planejamento_encontros e colunas CM/L + assinatura
- PUT substitui encontros; GET sugestão de datas (1º aluno)
- Validação de período sobreposto para mesmo professor/aluno