### PR TITLE
feat(api): relatos de atendimento (Fase 5) — modelo, migração e API

### DIFF
--- a/apps/api/Controllers/RelatoAtendimentoController.cs
+++ b/apps/api/Controllers/RelatoAtendimentoController.cs
@@ -1,0 +1,99 @@
+using api.DTOs.RelatoAtendimento;
+using api.Models;
+using api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace api.Controllers;
+
+[Authorize(Roles = "Professor, Admin")]
+[ApiController]
+[Route("api/[controller]")]
+public class RelatoAtendimentoController : ControllerBase
+{
+    private readonly RelatoAtendimentoService _service;
+    private readonly UserManager<Usuario> _usuario;
+
+    public RelatoAtendimentoController(RelatoAtendimentoService service, UserManager<Usuario> usuario)
+    {
+        _service = service;
+        _usuario = usuario;
+    }
+
+    [HttpGet("listar")]
+    public async Task<IActionResult> Listar([FromQuery] int? alunoId, [FromQuery] DateOnly? dataInicio,
+        [FromQuery] DateOnly? dataFim)
+    {
+        var usuario = await _usuario.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.ListarAsync(usuario, alunoId, dataInicio, dataFim);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpGet("relatorio-consolidado")]
+    public async Task<IActionResult> RelatorioConsolidado([FromQuery] DateOnly dataInicio,
+        [FromQuery] DateOnly dataFim,
+        [FromQuery] int? alunoId)
+    {
+        var usuario = await _usuario.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.RelatorioConsolidadoAsync(usuario, dataInicio, dataFim, alunoId);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpGet("sugestoes-mes")]
+    public async Task<IActionResult> SugestoesMes([FromQuery] int alunoId, [FromQuery] int ano,
+        [FromQuery] int mes)
+    {
+        var usuario = await _usuario.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.SugestoesMesAsync(usuario, alunoId, ano, mes);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpPost("cadastro")]
+    public async Task<IActionResult> Cadastrar([FromBody] RelatoAtendimentoCadastroDTO dto)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+        var usuario = await _usuario.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.Cadastrar(dto, usuario);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpPatch("atualizar")]
+    public async Task<IActionResult> Atualizar([FromBody] RelatoAtendimentoAtualizarDTO dto)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+        var usuario = await _usuario.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.Atualizar(dto, usuario);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> Excluir(int id)
+    {
+        var usuario = await _usuario.GetUserAsync(User);
+        if (usuario == null)
+            return Unauthorized();
+
+        var resposta = await _service.Excluir(id, usuario);
+        return resposta.Sucesso ? Ok(resposta) : BadRequest(resposta);
+    }
+}

--- a/apps/api/DTOs/RelatoAtendimento/RelatoAtendimentoAtualizarDTO.cs
+++ b/apps/api/DTOs/RelatoAtendimento/RelatoAtendimentoAtualizarDTO.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using api.Models;
+
+namespace api.DTOs.RelatoAtendimento;
+
+public class RelatoAtendimentoAtualizarDTO
+{
+    [Required]
+    public int Id { get; set; }
+
+    public int? PlanejamentoId { get; set; }
+
+    [Required]
+    public DateOnly DataSessao { get; set; }
+
+    [Required]
+    public bool PresencaPresente { get; set; }
+
+    [Required]
+    public RelatoTipoOcorrencia TipoOcorrencia { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    public int? EstrategiaId { get; set; }
+
+    public string? Observacoes { get; set; }
+
+    public List<string> Avancos { get; set; } = [];
+
+    public List<string> Dificuldades { get; set; } = [];
+}

--- a/apps/api/DTOs/RelatoAtendimento/RelatoAtendimentoBuscarDTO.cs
+++ b/apps/api/DTOs/RelatoAtendimento/RelatoAtendimentoBuscarDTO.cs
@@ -1,0 +1,36 @@
+using api.Models;
+
+namespace api.DTOs.RelatoAtendimento;
+
+public class RelatoAtendimentoBuscarDTO
+{
+    public int Id { get; set; }
+
+    public int AlunoId { get; set; }
+
+    public string AlunoNome { get; set; } = "";
+
+    public int? PlanejamentoId { get; set; }
+
+    public string? PlanejamentoApelido { get; set; }
+
+    public DateOnly DataSessao { get; set; }
+
+    public bool PresencaPresente { get; set; }
+
+    public RelatoTipoOcorrencia TipoOcorrencia { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    public string? HabilidadeResumo { get; set; }
+
+    public int? EstrategiaId { get; set; }
+
+    public string? EstrategiaDescricao { get; set; }
+
+    public string? Observacoes { get; set; }
+
+    public List<string> Avancos { get; set; } = [];
+
+    public List<string> Dificuldades { get; set; } = [];
+}

--- a/apps/api/DTOs/RelatoAtendimento/RelatoAtendimentoCadastroDTO.cs
+++ b/apps/api/DTOs/RelatoAtendimento/RelatoAtendimentoCadastroDTO.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using api.Models;
+
+namespace api.DTOs.RelatoAtendimento;
+
+public class RelatoAtendimentoCadastroDTO
+{
+    [Required]
+    public int AlunoId { get; set; }
+
+    public int? PlanejamentoId { get; set; }
+
+    [Required]
+    public DateOnly DataSessao { get; set; }
+
+    [Required]
+    public bool PresencaPresente { get; set; }
+
+    [Required]
+    public RelatoTipoOcorrencia TipoOcorrencia { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    public int? EstrategiaId { get; set; }
+
+    public string? Observacoes { get; set; }
+
+    public List<string> Avancos { get; set; } = [];
+
+    public List<string> Dificuldades { get; set; } = [];
+}

--- a/apps/api/DTOs/RelatoAtendimento/RelatoSugestoesMesDTO.cs
+++ b/apps/api/DTOs/RelatoAtendimento/RelatoSugestoesMesDTO.cs
@@ -1,0 +1,13 @@
+namespace api.DTOs.RelatoAtendimento;
+
+public class RelatoSugestoesMesDTO
+{
+    public int Ano { get; set; }
+
+    public int Mes { get; set; }
+
+    public List<DateOnly> DatasSugeridas { get; set; } = [];
+
+    /// <summary>Datas do mês já com relato registrado (mesmo aluno).</summary>
+    public List<DateOnly> DatasComRelatoRegistrado { get; set; } = [];
+}

--- a/apps/api/Data/AppDbContext.cs
+++ b/apps/api/Data/AppDbContext.cs
@@ -38,6 +38,7 @@ namespace Data
         public DbSet<EstudoDeCasoEixoCatalogo> EstudoCasoEixosCatalogo { get; set; }
         public DbSet<EstudoDeCaso> EstudosCaso { get; set; }
         public DbSet<EstudoDeCasoItemEixo> EstudoCasoItensEixo { get; set; }
+        public DbSet<RelatoAtendimento> RelatosAtendimento { get; set; }
 
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -258,6 +259,41 @@ namespace Data
                 .WithMany(c => c.Itens)
                 .HasForeignKey(i => i.EixoCatalogoId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<RelatoAtendimento>()
+                .HasOne(r => r.Aluno)
+                .WithMany()
+                .HasForeignKey(r => r.AlunoId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            modelBuilder.Entity<RelatoAtendimento>()
+                .HasOne(r => r.Planejamento)
+                .WithMany()
+                .HasForeignKey(r => r.PlanejamentoId)
+                .OnDelete(DeleteBehavior.SetNull)
+                .IsRequired(false);
+
+            modelBuilder.Entity<RelatoAtendimento>()
+                .HasOne(r => r.Habilidade)
+                .WithMany()
+                .HasForeignKey(r => r.HabilidadeId)
+                .OnDelete(DeleteBehavior.SetNull)
+                .IsRequired(false);
+
+            modelBuilder.Entity<RelatoAtendimento>()
+                .HasOne(r => r.Estrategia)
+                .WithMany()
+                .HasForeignKey(r => r.EstrategiaId)
+                .OnDelete(DeleteBehavior.SetNull)
+                .IsRequired(false);
+
+            modelBuilder.Entity<RelatoAtendimento>()
+                .Property(r => r.TipoOcorrencia)
+                .HasConversion<int>();
+
+            modelBuilder.Entity<RelatoAtendimento>()
+                .HasIndex(r => new { r.AlunoId, r.DataSessao })
+                .HasDatabaseName("ix_relatos_atendimento_alunoid_datasessao");
 
         }
 

--- a/apps/api/Migrations/20260525225923_Fase5RelatosAtendimento.Designer.cs
+++ b/apps/api/Migrations/20260525225923_Fase5RelatosAtendimento.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525225923_Fase5RelatosAtendimento")]
+    partial class Fase5RelatosAtendimento
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/Migrations/20260525225923_Fase5RelatosAtendimento.cs
+++ b/apps/api/Migrations/20260525225923_Fase5RelatosAtendimento.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class Fase5RelatosAtendimento : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "relatos_atendimento",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    alunoid = table.Column<int>(type: "integer", nullable: false),
+                    planejamentoid = table.Column<int>(type: "integer", nullable: true),
+                    datasessao = table.Column<DateOnly>(type: "date", nullable: false),
+                    presencapresente = table.Column<bool>(type: "boolean", nullable: false),
+                    tipoocorrencia = table.Column<int>(type: "integer", nullable: false),
+                    habilidadeid = table.Column<int>(type: "integer", nullable: true),
+                    estrategiaid = table.Column<int>(type: "integer", nullable: true),
+                    observacoes = table.Column<string>(type: "text", nullable: true),
+                    avancosjson = table.Column<string>(type: "text", nullable: true),
+                    dificuldadesjson = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_relatos_atendimento", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_relatos_atendimento_alunos_alunoid",
+                        column: x => x.alunoid,
+                        principalTable: "alunos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_relatos_atendimento_estrategias_estrategiaid",
+                        column: x => x.estrategiaid,
+                        principalTable: "estrategias",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "fk_relatos_atendimento_habilidades_habilidadeid",
+                        column: x => x.habilidadeid,
+                        principalTable: "habilidades",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "fk_relatos_atendimento_planejamentos_planejamentoid",
+                        column: x => x.planejamentoid,
+                        principalTable: "planejamentos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_relatos_atendimento_alunoid_datasessao",
+                table: "relatos_atendimento",
+                columns: new[] { "alunoid", "datasessao" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_relatos_atendimento_estrategiaid",
+                table: "relatos_atendimento",
+                column: "estrategiaid");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_relatos_atendimento_habilidadeid",
+                table: "relatos_atendimento",
+                column: "habilidadeid");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_relatos_atendimento_planejamentoid",
+                table: "relatos_atendimento",
+                column: "planejamentoid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "relatos_atendimento");
+        }
+    }
+}

--- a/apps/api/Models/RelatoAtendimento.cs
+++ b/apps/api/Models/RelatoAtendimento.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace api.Models;
+
+[Table("relatos_atendimento")]
+public class RelatoAtendimento
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int Id { get; set; }
+
+    public int AlunoId { get; set; }
+
+    [ForeignKey("AlunoId")]
+    public Aluno Aluno { get; set; } = null!;
+
+    /// <summary>PAEE vinculado; quando informado, habilidade/estratégia devem constar no plano.</summary>
+    public int? PlanejamentoId { get; set; }
+
+    [ForeignKey("PlanejamentoId")]
+    public Planejamento? Planejamento { get; set; }
+
+    public DateOnly DataSessao { get; set; }
+
+    /// <summary>Presença do aluno na sessão (obrigatório informar true ou false).</summary>
+    public bool PresencaPresente { get; set; }
+
+    public RelatoTipoOcorrencia TipoOcorrencia { get; set; }
+
+    public int? HabilidadeId { get; set; }
+
+    [ForeignKey("HabilidadeId")]
+    public Habilidade? Habilidade { get; set; }
+
+    public int? EstrategiaId { get; set; }
+
+    [ForeignKey("EstrategiaId")]
+    public Estrategias? Estrategia { get; set; }
+
+    [Column(TypeName = "text")]
+    public string? Observacoes { get; set; }
+
+    /// <summary>JSON array de strings.</summary>
+    [Column(TypeName = "text")]
+    public string AvancosJson { get; set; } = "[]";
+
+    /// <summary>JSON array de strings.</summary>
+    [Column(TypeName = "text")]
+    public string DificuldadesJson { get; set; } = "[]";
+}

--- a/apps/api/Models/RelatoTipoOcorrencia.cs
+++ b/apps/api/Models/RelatoTipoOcorrencia.cs
@@ -1,0 +1,9 @@
+namespace api.Models;
+
+/// <summary>Ocorrência registrada na sessão de atendimento.</summary>
+public enum RelatoTipoOcorrencia
+{
+    Normal = 0,
+    Cancelada = 1,
+    Reagendada = 2,
+}

--- a/apps/api/Program.cs
+++ b/apps/api/Program.cs
@@ -158,6 +158,7 @@ builder.Services.AddHttpClient();
 builder.Services.AddScoped<HotmartService>();
 builder.Services.AddScoped<AvaliacaoDiagnosticaService>();
 builder.Services.AddScoped<EstudoDeCasoService>();
+builder.Services.AddScoped<RelatoAtendimentoService>();
 builder.Services.AddScoped<AdminService>();
 builder.Services.AddScoped<AtividadeService>();
 builder.Services.AddScoped<EmailService>();

--- a/apps/api/Services/RelatoAtendimentoService.cs
+++ b/apps/api/Services/RelatoAtendimentoService.cs
@@ -1,0 +1,429 @@
+using System.Text.Json;
+using api.DTOs.RelatoAtendimento;
+using api.Models;
+using api.Responses;
+using Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace api.Services;
+
+public class RelatoAtendimentoService
+{
+    private static readonly JsonSerializerOptions JsonLista = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false,
+    };
+
+    private readonly AppDbContext _db;
+
+    public RelatoAtendimentoService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    private static string SerializarLista(IReadOnlyCollection<string>? itens)
+    {
+        var lista = (itens ?? []).Where(static s => !string.IsNullOrWhiteSpace(s)).Select(static s => s.Trim()).ToList();
+        return JsonSerializer.Serialize(lista, JsonLista);
+    }
+
+    private static List<string> DeserializarLista(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json, JsonLista) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static RelatoAtendimentoBuscarDTO MapToBuscarDto(RelatoAtendimento r) =>
+        new()
+        {
+            Id = r.Id,
+            AlunoId = r.AlunoId,
+            AlunoNome = r.Aluno?.NomeCompleto ?? "",
+            PlanejamentoId = r.PlanejamentoId,
+            PlanejamentoApelido = r.Planejamento?.Apelido,
+            DataSessao = r.DataSessao,
+            PresencaPresente = r.PresencaPresente,
+            TipoOcorrencia = r.TipoOcorrencia,
+            HabilidadeId = r.HabilidadeId,
+            HabilidadeResumo = r.Habilidade != null ? (r.Habilidade.Resumo ?? r.Habilidade.Descricao) : null,
+            EstrategiaId = r.EstrategiaId,
+            EstrategiaDescricao = r.Estrategia?.Descricao,
+            Observacoes = r.Observacoes,
+            Avancos = DeserializarLista(r.AvancosJson),
+            Dificuldades = DeserializarLista(r.DificuldadesJson),
+        };
+
+    /// <returns>Mensagem de erro ou null se válido.</returns>
+    private async Task<string?> ValidarNegocioAsync(
+        int professorId,
+        int alunoId,
+        int? planejamentoId,
+        DateOnly dataSessao,
+        int? habilidadeId,
+        int? estrategiaId,
+        bool presencaPresente,
+        RelatoTipoOcorrencia tipoOcorrencia,
+        string? observacoes)
+    {
+        if (!presencaPresente && string.IsNullOrWhiteSpace(observacoes))
+            return "Informe observações quando o aluno não esteve presente.";
+
+        if (tipoOcorrencia != RelatoTipoOcorrencia.Normal && string.IsNullOrWhiteSpace(observacoes))
+            return "Informe observações quando a ocorrência não for sessão normal (cancelada ou reagendada).";
+
+        var aluno = await _db.Alunos.AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == alunoId && a.IdProfessor == professorId);
+        if (aluno == null)
+            return "Aluno não encontrado ou sem permissão.";
+
+        if (!planejamentoId.HasValue)
+        {
+            if (habilidadeId.HasValue)
+            {
+                var existeH = await _db.Habilidades.AnyAsync(h => h.Id == habilidadeId.Value);
+                if (!existeH)
+                    return "Habilidade não encontrada.";
+            }
+
+            if (estrategiaId.HasValue)
+            {
+                var existeE = await _db.Estrategias.AnyAsync(e => e.Id == estrategiaId.Value);
+                if (!existeE)
+                    return "Estratégia não encontrada.";
+            }
+
+            return null;
+        }
+
+        var plano = await _db.Planejamentos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p =>
+                p.ID == planejamentoId.Value &&
+                p.IdProfessor == professorId);
+
+        if (plano == null)
+            return "PAEE não encontrado ou sem permissão.";
+
+        var alunoNoPlano = await _db.AlunosXPlanejamentos
+            .AnyAsync(x => x.PlanejamentoId == planejamentoId.Value && x.AlunoId == alunoId);
+        if (!alunoNoPlano)
+            return "O aluno não está vinculado ao PAEE informado.";
+
+        if (dataSessao < plano.DataInicio || dataSessao > plano.DataFim)
+            return "A data da sessão precisa estar dentro do período do PAEE escolhido.";
+
+        if (habilidadeId.HasValue)
+        {
+            var ok = await _db.HabilidadesXPlanejamentos
+                .AnyAsync(x =>
+                    x.PlanejamentoId == planejamentoId.Value &&
+                    x.HabilidadeId == habilidadeId.Value);
+            if (!ok)
+                return "A habilidade informada não faz parte deste PAEE.";
+        }
+
+        if (estrategiaId.HasValue)
+        {
+            var ok = await _db.EstrategiasXPlanejamentos
+                .AnyAsync(x =>
+                    x.PlanejamentoId == planejamentoId.Value &&
+                    x.EstrategiaId == estrategiaId.Value);
+            if (!ok)
+                return "A estratégia informada não faz parte deste PAEE.";
+        }
+
+        return null;
+    }
+
+    private IQueryable<RelatoAtendimento> BaseQueryProfessor(int professorId) =>
+        _db.RelatosAtendimento
+            .Include(r => r.Aluno)
+            .Include(r => r.Planejamento)
+            .Include(r => r.Habilidade)
+            .Include(r => r.Estrategia)
+            .Where(r => r.Aluno!.IdProfessor == professorId);
+
+    public async Task<ServiceResponse<RelatoAtendimentoBuscarDTO>> Cadastrar(
+        RelatoAtendimentoCadastroDTO dto,
+        Usuario usuario)
+    {
+        var resposta = new ServiceResponse<RelatoAtendimentoBuscarDTO>();
+        var professorId = usuario.ProfessorId ?? 0;
+        if (professorId == 0)
+        {
+            resposta.SetFalha("Professor não identificado.");
+            return resposta;
+        }
+
+        var erro = await ValidarNegocioAsync(
+            professorId,
+            dto.AlunoId,
+            dto.PlanejamentoId,
+            dto.DataSessao,
+            dto.HabilidadeId,
+            dto.EstrategiaId,
+            dto.PresencaPresente,
+            dto.TipoOcorrencia,
+            dto.Observacoes);
+        if (erro != null)
+        {
+            resposta.SetFalha(erro);
+            return resposta;
+        }
+
+        try
+        {
+            var ent = new RelatoAtendimento
+            {
+                AlunoId = dto.AlunoId,
+                PlanejamentoId = dto.PlanejamentoId,
+                DataSessao = dto.DataSessao,
+                PresencaPresente = dto.PresencaPresente,
+                TipoOcorrencia = dto.TipoOcorrencia,
+                HabilidadeId = dto.HabilidadeId,
+                EstrategiaId = dto.EstrategiaId,
+                Observacoes = dto.Observacoes?.Trim(),
+                AvancosJson = SerializarLista(dto.Avancos),
+                DificuldadesJson = SerializarLista(dto.Dificuldades),
+            };
+
+            _db.RelatosAtendimento.Add(ent);
+            await _db.SaveChangesAsync();
+
+            var carregado = await BaseQueryProfessor(professorId).FirstAsync(r => r.Id == ent.Id);
+
+            resposta.AdicionaObjeto(MapToBuscarDto(carregado));
+            resposta.AdicionaMensagem("Relato registrado.");
+            return resposta;
+        }
+        catch (Exception ex)
+        {
+            resposta.SetFalha(ex.Message);
+            return resposta;
+        }
+    }
+
+    public async Task<ServiceResponse<RelatoAtendimentoBuscarDTO>> Atualizar(
+        RelatoAtendimentoAtualizarDTO dto,
+        Usuario usuario)
+    {
+        var resposta = new ServiceResponse<RelatoAtendimentoBuscarDTO>();
+        var professorId = usuario.ProfessorId ?? 0;
+        if (professorId == 0)
+        {
+            resposta.SetFalha("Professor não identificado.");
+            return resposta;
+        }
+
+        var ent = await BaseQueryProfessor(professorId).FirstOrDefaultAsync(r => r.Id == dto.Id);
+        if (ent == null)
+        {
+            resposta.SetFalha("Relato não encontrado.");
+            return resposta;
+        }
+
+        var erro = await ValidarNegocioAsync(
+            professorId,
+            ent.AlunoId,
+            dto.PlanejamentoId,
+            dto.DataSessao,
+            dto.HabilidadeId,
+            dto.EstrategiaId,
+            dto.PresencaPresente,
+            dto.TipoOcorrencia,
+            dto.Observacoes);
+        if (erro != null)
+        {
+            resposta.SetFalha(erro);
+            return resposta;
+        }
+
+        try
+        {
+            ent.PlanejamentoId = dto.PlanejamentoId;
+            ent.DataSessao = dto.DataSessao;
+            ent.PresencaPresente = dto.PresencaPresente;
+            ent.TipoOcorrencia = dto.TipoOcorrencia;
+            ent.HabilidadeId = dto.HabilidadeId;
+            ent.EstrategiaId = dto.EstrategiaId;
+            ent.Observacoes = dto.Observacoes?.Trim();
+            ent.AvancosJson = SerializarLista(dto.Avancos);
+            ent.DificuldadesJson = SerializarLista(dto.Dificuldades);
+
+            await _db.SaveChangesAsync();
+
+            var carregado = await BaseQueryProfessor(professorId).FirstAsync(r => r.Id == ent.Id);
+
+            resposta.AdicionaObjeto(MapToBuscarDto(carregado));
+            resposta.AdicionaMensagem("Relato atualizado.");
+            return resposta;
+        }
+        catch (Exception ex)
+        {
+            resposta.SetFalha(ex.Message);
+            return resposta;
+        }
+    }
+
+    public async Task<ServiceResponse<bool>> Excluir(int id, Usuario usuario)
+    {
+        var resposta = new ServiceResponse<bool>();
+        var professorId = usuario.ProfessorId ?? 0;
+        if (professorId == 0)
+        {
+            resposta.SetFalha("Professor não identificado.");
+            return resposta;
+        }
+
+        var ent = await BaseQueryProfessor(professorId).FirstOrDefaultAsync(r => r.Id == id);
+        if (ent == null)
+        {
+            resposta.SetFalha("Relato não encontrado.");
+            return resposta;
+        }
+
+        _db.RelatosAtendimento.Remove(ent);
+        await _db.SaveChangesAsync();
+        resposta.AdicionaObjeto(true);
+        resposta.AdicionaMensagem("Relato excluído.");
+        return resposta;
+    }
+
+    public async Task<ServiceResponse<RelatoAtendimentoBuscarDTO>> ListarAsync(
+        Usuario usuario,
+        int? alunoId,
+        DateOnly? dataInicio,
+        DateOnly? dataFim)
+    {
+        var resposta = new ServiceResponse<RelatoAtendimentoBuscarDTO>();
+        var professorId = usuario.ProfessorId ?? 0;
+        if (professorId == 0)
+        {
+            resposta.SetFalha("Professor não identificado.");
+            return resposta;
+        }
+
+        var q = BaseQueryProfessor(professorId);
+        if (alunoId.HasValue)
+            q = q.Where(r => r.AlunoId == alunoId.Value);
+
+        if (dataInicio.HasValue)
+            q = q.Where(r => r.DataSessao >= dataInicio.Value);
+
+        if (dataFim.HasValue)
+            q = q.Where(r => r.DataSessao <= dataFim.Value);
+
+        var lista = await q
+            .OrderByDescending(r => r.DataSessao)
+            .ThenByDescending(r => r.Id)
+            .ToListAsync();
+
+        resposta.AdicionaObjetos(lista.Select(MapToBuscarDto));
+        return resposta;
+    }
+
+    public async Task<ServiceResponse<RelatoAtendimentoBuscarDTO>> RelatorioConsolidadoAsync(
+        Usuario usuario,
+        DateOnly dataInicio,
+        DateOnly dataFim,
+        int? alunoId)
+    {
+        var resposta = new ServiceResponse<RelatoAtendimentoBuscarDTO>();
+        var professorId = usuario.ProfessorId ?? 0;
+        if (professorId == 0)
+        {
+            resposta.SetFalha("Professor não identificado.");
+            return resposta;
+        }
+
+        if (dataInicio > dataFim)
+        {
+            resposta.SetFalha("Data inicial não pode ser posterior à final.");
+            return resposta;
+        }
+
+        var q = BaseQueryProfessor(professorId)
+            .Where(r => r.DataSessao >= dataInicio && r.DataSessao <= dataFim);
+
+        if (alunoId.HasValue)
+            q = q.Where(r => r.AlunoId == alunoId.Value);
+
+        var lista = await q
+            .OrderBy(r => r.DataSessao)
+            .ThenBy(r => r.Aluno!.NomeCompleto)
+            .ThenBy(r => r.Id)
+            .ToListAsync();
+
+        resposta.AdicionaObjetos(lista.Select(MapToBuscarDto));
+        return resposta;
+    }
+
+    public async Task<ServiceResponse<RelatoSugestoesMesDTO>> SugestoesMesAsync(
+        Usuario usuario,
+        int alunoId,
+        int ano,
+        int mes)
+    {
+        var resposta = new ServiceResponse<RelatoSugestoesMesDTO>();
+        var professorId = usuario.ProfessorId ?? 0;
+        if (professorId == 0)
+        {
+            resposta.SetFalha("Professor não identificado.");
+            return resposta;
+        }
+
+        if (mes is < 1 or > 12)
+        {
+            resposta.SetFalha("Mês inválido.");
+            return resposta;
+        }
+
+        try
+        {
+            var ini = new DateOnly(ano, mes, 1);
+            var fim = ini.AddMonths(1).AddDays(-1);
+
+            var aluno = await _db.Alunos.AsNoTracking()
+                .FirstOrDefaultAsync(a => a.Id == alunoId && a.IdProfessor == professorId);
+            if (aluno == null)
+            {
+                resposta.SetFalha("Aluno não encontrado.");
+                return resposta;
+            }
+
+            var dias = PaeeDatasSugeridasGerador.DeserializarDiasDaSemana(aluno.DiasSemanaAtendimentoJson);
+            var todas = PaeeDatasSugeridasGerador.Sugerir(ini, fim, dias, aluno.FrequenciaSemanalAtendimento).ToList();
+
+            var comRelato = await _db.RelatosAtendimento
+                .Where(r => r.AlunoId == alunoId && r.DataSessao >= ini && r.DataSessao <= fim)
+                .Select(r => r.DataSessao)
+                .Distinct()
+                .ToListAsync();
+
+            var resultado = new RelatoSugestoesMesDTO
+            {
+                Ano = ano,
+                Mes = mes,
+                DatasSugeridas = todas,
+                DatasComRelatoRegistrado = comRelato.OrderBy(d => d).ToList(),
+            };
+
+            resposta.AdicionaObjeto(resultado);
+            return resposta;
+        }
+        catch (Exception ex)
+        {
+            resposta.SetFalha(ex.Message);
+            return resposta;
+        }
+    }
+}


### PR DESCRIPTION
Persistência relatos_atendimento, enums/validações com PAEE opcional, relatório consolidado e sugestões de mês para registro das sessões.